### PR TITLE
Blobs, tests for them, an more tests in general

### DIFF
--- a/src/NexusMods.MnemonicDB.Abstractions/Attributes/BlobAttribute.cs
+++ b/src/NexusMods.MnemonicDB.Abstractions/Attributes/BlobAttribute.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Buffers;
+using NexusMods.MnemonicDB.Abstractions.ElementComparers;
+
+namespace NexusMods.MnemonicDB.Abstractions.Attributes;
+
+/// <summary>
+/// An abstract class for a blob attribute, the values for this attribute are inlined into the key in the datom store,
+/// so try to keep the sizes small. The actual limit is based on the underlying storage engine. For larger values
+/// use the HashedBlobAttribute.
+/// </summary>
+public abstract class BlobAttribute<TValue>(string ns, string name) : Attribute<TValue, byte[]>(ValueTags.Blob, ns, name)
+{
+    /// <inheritdoc />
+    public override void Write<TWriter>(EntityId entityId, RegistryId registryId, TValue value, TxId txId, bool isRetract, TWriter writer)
+    {
+        WritePrefix(entityId, registryId, txId, isRetract, writer);
+        var span = writer.GetSpan(1);
+        span[0] = (byte)ValueTags.Blob;
+        writer.Advance(1);
+        WriteValue(value, writer);
+    }
+
+    protected override byte[] ToLowLevel(TValue value)
+    {
+        throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// Overwrite this method to read the value from the reader
+    /// </summary>
+    protected abstract override TValue FromLowLevel(ReadOnlySpan<byte> value, ValueTags tag);
+
+    /// <summary>
+    /// Overwrite this method to write the value to the writer
+    /// </summary>
+    protected abstract void WriteValue<TWriter>(TValue value, TWriter writer)
+        where TWriter : IBufferWriter<byte>;
+}

--- a/src/NexusMods.MnemonicDB.Abstractions/Attributes/HashedBlobAttribute.cs
+++ b/src/NexusMods.MnemonicDB.Abstractions/Attributes/HashedBlobAttribute.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Buffers;
+using System.IO.Hashing;
+using System.Runtime.InteropServices;
+using NexusMods.MnemonicDB.Abstractions.ElementComparers;
+using Reloaded.Memory.Extensions;
+
+namespace NexusMods.MnemonicDB.Abstractions.Attributes;
+
+public abstract class HashedBlobAttribute<TValue>(string ns, string name) : Attribute<TValue, byte[]>(ValueTags.HashedBlob, ns, name)
+{
+    public override void Write<TWriter>(EntityId entityId, RegistryId registryId, TValue value, TxId txId, bool isRetract, TWriter writer)
+    {
+        using var innerWriter = new PooledMemoryBufferWriter();
+        WritePrefix(entityId, registryId, txId, isRetract, writer);
+
+        WriteValue(value, innerWriter);
+        var valueSpan = innerWriter.GetWrittenSpan();
+
+        var hash = XxHash3.HashToUInt64(valueSpan);
+
+        var writerSpan = writer.GetSpan(sizeof(ulong) + 1);
+        writerSpan[0] = (byte)ValueTags.HashedBlob;
+        MemoryMarshal.Write(writerSpan.SliceFast(1), hash);
+        writer.Advance(sizeof(ulong) + 1);
+        writer.Write(valueSpan);
+    }
+
+
+    /// <inheritdoc />
+    protected override byte[] ToLowLevel(TValue value)
+    {
+        throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// Overwrite this method to read the value from the reader
+    /// </summary>
+    protected abstract override TValue FromLowLevel(ReadOnlySpan<byte> value, ValueTags tag);
+
+    /// <summary>
+    /// Overwrite this method to write the value to the writer
+    /// </summary>
+    protected abstract void WriteValue<TWriter>(TValue value, TWriter writer)
+        where TWriter : IBufferWriter<byte>;
+}

--- a/src/NexusMods.MnemonicDB.Abstractions/ElementComparers/ValueComparer.cs
+++ b/src/NexusMods.MnemonicDB.Abstractions/ElementComparers/ValueComparer.cs
@@ -65,6 +65,7 @@ public class ValueComparer : IElementComparer
             ValueTags.Utf8 => CompareBlobInternal(aVal, alen, bVal, blen),
             ValueTags.Utf8Insensitive => CompareUtf8Insensitive(aVal, alen, bVal, blen),
             ValueTags.Blob => CompareBlobInternal(aVal, alen, bVal, blen),
+            ValueTags.HashedBlob => CompareBlobInternal(aVal, alen, bVal, blen),
             ValueTags.Reference => CompareInternal<ulong>(aVal, bVal),
             _ => ThrowInvalidCompare()
         };

--- a/src/NexusMods.MnemonicDB.Abstractions/ElementComparers/ValueTags.cs
+++ b/src/NexusMods.MnemonicDB.Abstractions/ElementComparers/ValueTags.cs
@@ -66,10 +66,16 @@ public enum ValueTags : byte
     /// Inline binary data
     /// </summary>
     Blob = 15,
-    
+
+    /// <summary>
+    /// A blob sorted by its xxHash64 hash, and where the data is possibly stored in a separate location
+    /// as to degrade the performance of the key storage
+    /// </summary>
+    HashedBlob = 16,
+
     /// <summary>
     /// A reference to another entity
     /// </summary>
-    Reference = 16,
+    Reference = 17,
 
 }

--- a/src/NexusMods.MnemonicDB.Abstractions/NexusMods.MnemonicDB.Abstractions.csproj
+++ b/src/NexusMods.MnemonicDB.Abstractions/NexusMods.MnemonicDB.Abstractions.csproj
@@ -9,6 +9,7 @@
         <PackageReference Include="MemoryPack.Core" Version="1.20.5"/>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1"/>
         <PackageReference Include="NexusMods.Paths" Version="0.9.0"/>
+        <PackageReference Include="System.IO.Hashing" Version="8.0.0" />
         <PackageReference Include="TransparentValueObjects" Version="1.0.1" PrivateAssets="all" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>
         <PackageReference Update="JetBrains.Annotations" Version="2023.3.0"/>
     </ItemGroup>

--- a/src/NexusMods.MnemonicDB.Storage/RocksDbBackend/Backend.cs
+++ b/src/NexusMods.MnemonicDB.Storage/RocksDbBackend/Backend.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.MnemonicDB.Abstractions.DatomComparators;
 using NexusMods.MnemonicDB.Abstractions.DatomIterators;
+using NexusMods.MnemonicDB.Abstractions.ElementComparers;
+using NexusMods.MnemonicDB.Abstractions.Internals;
 using NexusMods.MnemonicDB.Storage.Abstractions;
 using NexusMods.Paths;
 using RocksDbSharp;
@@ -105,6 +107,16 @@ public class Backend(AttributeRegistry registry) : IStoreBackend
             {
                 writer.Reset();
                 writer.Write(iterator.GetKeySpan());
+
+                if (writer.Length >= KeyPrefix.Size + 1)
+                {
+                    var tag = (ValueTags)writer.GetWrittenSpan()[KeyPrefix.Size];
+                    if (tag == ValueTags.HashedBlob)
+                    {
+                        writer.Write(iterator.GetValueSpan());
+                    }
+                }
+
                 yield return new Datom(writer.WrittenMemory, registry);
 
                 if (reverse)

--- a/src/NexusMods.MnemonicDB.Storage/RocksDbBackend/Batch.cs
+++ b/src/NexusMods.MnemonicDB.Storage/RocksDbBackend/Batch.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using NexusMods.MnemonicDB.Abstractions.ElementComparers;
+using NexusMods.MnemonicDB.Abstractions.Internals;
 using NexusMods.MnemonicDB.Storage.Abstractions;
+using Reloaded.Memory.Extensions;
 using RocksDbSharp;
 using IWriteBatch = NexusMods.MnemonicDB.Storage.Abstractions.IWriteBatch;
 
@@ -14,13 +17,32 @@ public class Batch(RocksDb db) : IWriteBatch
         _batch.Dispose();
     }
 
+    private ValueTags Tag(ReadOnlySpan<byte> key)
+    {
+        if (key.Length < KeyPrefix.Size + 1)
+            return ValueTags.Null;
+        return (ValueTags)key[KeyPrefix.Size];
+    }
+
     public void Add(IIndexStore store, ReadOnlySpan<byte> key)
     {
-        _batch.Put(key, ReadOnlySpan<byte>.Empty, ((IRocksDBIndexStore)store).Handle);
+        var outOfBandData = ReadOnlySpan<byte>.Empty;
+        if (Tag(key) == ValueTags.HashedBlob)
+        {
+            outOfBandData = key.SliceFast(KeyPrefix.Size + 1 + sizeof(ulong));
+            key = key.SliceFast(0, KeyPrefix.Size + 1 + sizeof(ulong));
+        }
+
+        _batch.Put(key, outOfBandData, ((IRocksDBIndexStore)store).Handle);
     }
 
     public void Delete(IIndexStore store, ReadOnlySpan<byte> key)
     {
+        if (Tag(key) == ValueTags.HashedBlob)
+        {
+            key = key.SliceFast(0, KeyPrefix.Size + 1 + sizeof(ulong));
+        }
+
         _batch.Delete(key, ((IRocksDBIndexStore)store).Handle);
     }
 

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/AStorageTest.cs
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/AStorageTest.cs
@@ -4,6 +4,7 @@ using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.MnemonicDB.Abstractions.ElementComparers;
 using NexusMods.MnemonicDB.Storage.Abstractions;
 using NexusMods.MnemonicDB.Storage.RocksDbBackend;
+using NexusMods.MnemonicDB.Storage.Tests.TestAttributes;
 using NexusMods.MnemonicDB.TestModel;
 using NexusMods.Paths;
 using File = NexusMods.MnemonicDB.TestModel.File;
@@ -36,7 +37,9 @@ public abstract class AStorageTest : IAsyncLifetime
             new DbAttribute(Loadout.Name.Id, AttributeId.From(26), ValueTags.Utf8),
             new DbAttribute(Collection.Name.Id, AttributeId.From(27), ValueTags.Utf8),
             new DbAttribute(Collection.Loadout.Id, AttributeId.From(28), ValueTags.Reference),
-            new DbAttribute(Collection.Mods.Id, AttributeId.From(29), ValueTags.Reference)
+            new DbAttribute(Collection.Mods.Id, AttributeId.From(29), ValueTags.Reference),
+            new DbAttribute(Blobs.InKeyBlob.Id, AttributeId.From(30), ValueTags.Blob),
+            new DbAttribute(Blobs.InValueBlob.Id, AttributeId.From(31), ValueTags.HashedBlob)
         ]);
         _path = FileSystem.Shared.GetKnownPath(KnownPath.EntryDirectory).Combine("tests_datomstore" + Guid.NewGuid());
 

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.CanStoreDataInBlobs.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.CanStoreDataInBlobs.verified.txt
@@ -1,0 +1,6 @@
+﻿+ | 0000000000000001 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/UniqueId         | 0100000000000001
++ | 0000000000000001 | (0002) ValueType                | Ascii                                            | 0100000000000001
++ | 0000000000000002 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/ValueType        | 0100000000000001
++ | 0000000000000002 | (0002) ValueType                | UInt8                                            | 0100000000000001
++ | 0200000000000001 | (001E) InKeyBlob                | Blob 0xB85FD37A0A050E63 255 bytes                | 0100000000000002
++ | 0200000000000001 | (001F) InValueBlob              | Blob 0xB85FD37A0A050E63 255 bytes                | 0100000000000002

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.CanStoreDataInBlobs.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.CanStoreDataInBlobs.verified.txt
@@ -1,0 +1,6 @@
+﻿+ | 0000000000000001 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/UniqueId         | 0100000000000001
++ | 0000000000000001 | (0002) ValueType                | Ascii                                            | 0100000000000001
++ | 0000000000000002 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/ValueType        | 0100000000000001
++ | 0000000000000002 | (0002) ValueType                | UInt8                                            | 0100000000000001
++ | 0200000000000001 | (001E) InKeyBlob                | Blob 0xB85FD37A0A050E63 255 bytes                | 0100000000000002
++ | 0200000000000001 | (001F) InValueBlob              | Blob 0xB85FD37A0A050E63 255 bytes                | 0100000000000002

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/NexusMods.MnemonicDB.Storage.Tests.csproj
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/NexusMods.MnemonicDB.Storage.Tests.csproj
@@ -63,4 +63,8 @@
         <ProjectReference Include="..\NexusMods.MnemonicDB.TestModel\NexusMods.MnemonicDB.TestModel.csproj"/>
     </ItemGroup>
 
+    <ItemGroup>
+      <None Remove="InMemoryTests.CanStoreDataInBlobs.verified.txt" />
+    </ItemGroup>
+
 </Project>

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/Startup.cs
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/Startup.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Logging;
 using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.MnemonicDB.Storage.RocksDbBackend;
+using NexusMods.MnemonicDB.Storage.Tests.TestAttributes;
 using NexusMods.MnemonicDB.TestModel;
 using Xunit.DependencyInjection.Logging;
 using File = NexusMods.MnemonicDB.TestModel.File;
@@ -18,6 +19,7 @@ public class Startup
             .AddAttributeCollection(typeof(File))
             .AddAttributeCollection(typeof(Mod))
             .AddAttributeCollection(typeof(Collection))
-            .AddAttributeCollection(typeof(Loadout));
+            .AddAttributeCollection(typeof(Loadout))
+            .AddAttributeCollection(typeof(Blobs));
     }
 }

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/TestAttributes/Blobs.cs
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/TestAttributes/Blobs.cs
@@ -1,0 +1,34 @@
+﻿using System.Buffers;
+using NexusMods.MnemonicDB.Abstractions.Attributes;
+using NexusMods.MnemonicDB.Abstractions.ElementComparers;
+
+namespace NexusMods.MnemonicDB.Storage.Tests.TestAttributes;
+
+public class Blobs
+{
+    private const string Namespace = "NexusMods.MnemonicDB.Storage.Tests.TestAttributes";
+
+    public static readonly TestBlobAttribute InKeyBlob = new(Namespace, "InKeyBlob");
+    public static readonly TestHashedBlobAttribute InValueBlob = new(Namespace, "InValueBlob");
+}
+
+
+public class TestBlobAttribute(string ns, string name) : BlobAttribute<byte[]>(ns, name)
+{
+    protected override byte[] FromLowLevel(ReadOnlySpan<byte> value, ValueTags tag) => value.ToArray();
+
+    protected override void WriteValue<TWriter>(byte[] value, TWriter writer)
+    {
+        writer.Write(value);
+    }
+}
+
+public class TestHashedBlobAttribute(string ns, string name) : HashedBlobAttribute<byte[]>(ns, name)
+{
+    protected override byte[] FromLowLevel(ReadOnlySpan<byte> value, ValueTags tag) => value.ToArray();
+
+    protected override void WriteValue<TWriter>(byte[] value, TWriter writer)
+    {
+        writer.Write(value);
+    }
+}

--- a/tests/NexusMods.MnemonicDB.TestModel/Helpers/ExtensionMethods.cs
+++ b/tests/NexusMods.MnemonicDB.TestModel/Helpers/ExtensionMethods.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.IO.Hashing;
+using System.Text;
 using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.MnemonicDB.Abstractions.Internals;
 
@@ -56,6 +57,11 @@ public static class ExtensionMethods
                     break;
                 case ulong ul:
                     sb.Append(ul.ToString("X16").PadRight(48));
+                    break;
+                case byte[] byteArray:
+                    var code = XxHash3.HashToUInt64(byteArray);
+                    var hash = code.ToString("X16");
+                    sb.Append($"Blob 0x{hash} {byteArray.Length} bytes".PadRight(48));
                     break;
                 default:
                     sb.Append(TruncateOrPad(datom.ObjectValue.ToString()!, 48));


### PR DESCRIPTION
Implements two types of Blobs:

* Blobs (inline) - these are values that are stored inline with the rest of the key and may be limited in size (8MB with RocksDB), likely a serious performance problem with larger key sizes due to the whole value being compared whenever the datom is sorted
* HashedBlobs - these are values that are stored as a blob (byte span) but hashed, and the hash is stored in the Key, and the blob in the value of the KV store. The actual value data is ignored in all comparisons and only the hash is used.