### PR TITLE
Added: FindIndexedDatoms API for providing a lower level search utility.

### DIFF
--- a/src/NexusMods.MnemonicDB.Abstractions/IDb.cs
+++ b/src/NexusMods.MnemonicDB.Abstractions/IDb.cs
@@ -68,11 +68,15 @@ public interface IDb : IEquatable<IDb>, IDisposable
     /// </summary>
     IEnumerable<TValueType> GetAll<TValueType, TLowLevel>(EntityId modelId, Attribute<TValueType, TLowLevel> attribute);
 
-
     /// <summary>
     /// Finds all the entity ids that have the given attribute with the given value.
     /// </summary>
     IEnumerable<EntityId> FindIndexed<TValue, TLowLevel>(TValue value, Attribute<TValue, TLowLevel> attribute);
+
+    /// <summary>
+    /// Finds all the datoms have the given attribute with the given value.
+    /// </summary>
+    IEnumerable<Datom> FindIndexedDatoms<TValue, TLowLevel>(TValue value, Attribute<TValue, TLowLevel> attribute);
 
     /// <summary>
     /// Finds all the entity ids that have the given attribute.

--- a/src/NexusMods.MnemonicDB/Db.cs
+++ b/src/NexusMods.MnemonicDB/Db.cs
@@ -110,7 +110,12 @@ internal class Db : IDb
 
     public IEnumerable<EntityId> FindIndexed<TValue, TLowLevel>(TValue value, Attribute<TValue, TLowLevel> attribute)
     {
-        var attrId = attribute.GetDbId(_registry.Id);
+        return FindIndexedDatoms(value, attribute)
+            .Select(d => d.E);
+    }
+
+    public IEnumerable<Datom> FindIndexedDatoms<TValue, TLowLevel>(TValue value, Attribute<TValue, TLowLevel> attribute)
+    {
         if (!attribute.IsIndexed)
             throw new InvalidOperationException($"Attribute {attribute.Id} is not indexed");
 
@@ -120,11 +125,8 @@ internal class Db : IDb
         using var end = new PooledMemoryBufferWriter(64);
         attribute.Write(EntityId.MaxValueNoPartition, _registry.Id, value, TxId.MinValue, false, end);
 
-        var results = Snapshot
-            .Datoms(IndexType.AVETCurrent, start.GetWrittenSpan(), end.GetWrittenSpan())
-            .Select(d => d.E);
-
-        return results;
+        return Snapshot
+            .Datoms(IndexType.AVETCurrent, start.GetWrittenSpan(), end.GetWrittenSpan());;
     }
 
     public TModel Get<TModel>(EntityId id)


### PR DESCRIPTION
Provides a `FindIndexedDatoms` method that returns a lower level primitive than `FindIndexed`.

Use Case
----------

In my case, I need the `TransactionId` (TxId) that is not available otherwise from an indexed search. 