### PR TITLE
Add Tx functions

### DIFF
--- a/src/NexusMods.MnemonicDB.Abstractions/IDatomStore.cs
+++ b/src/NexusMods.MnemonicDB.Abstractions/IDatomStore.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using NexusMods.MnemonicDB.Abstractions.IndexSegments;
 using NexusMods.MnemonicDB.Abstractions.Internals;
+using NexusMods.MnemonicDB.Abstractions.TxFunctions;
 
 namespace NexusMods.MnemonicDB.Abstractions;
 
@@ -29,7 +30,7 @@ public interface IDatomStore : IDisposable
     /// <summary>
     ///     Transacts (adds) the given datoms into the store.
     /// </summary>
-    public Task<StoreResult> Transact(IndexSegment datoms);
+    public Task<StoreResult> Transact(IndexSegment datoms, HashSet<ITxFunction>? txFunctions = null, Func<ISnapshot, IDb>? databaseFactory = null);
 
     /// <summary>
     /// Executes an empty transaction. Returns a StoreResult valid asof the latest

--- a/src/NexusMods.MnemonicDB.Abstractions/ITransaction.cs
+++ b/src/NexusMods.MnemonicDB.Abstractions/ITransaction.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using NexusMods.MnemonicDB.Abstractions.Models;
+using NexusMods.MnemonicDB.Abstractions.TxFunctions;
 
 namespace NexusMods.MnemonicDB.Abstractions;
 
@@ -24,6 +25,12 @@ public interface ITransaction : IDisposable
     ///     Adds a new datom to the transaction
     /// </summary>
     void Add<TVal, TLowLevel>(EntityId entityId, Attribute<TVal, TLowLevel> attribute, TVal val, bool isRetract = false);
+
+    /// <summary>
+    /// Adds a transactor function to the transaction
+    /// </summary>
+    /// <param name="fn"></param>
+    void Add(ITxFunction fn);
 
     /// <summary>
     ///     Adds a new datom to the transaction, that retracts the value for the given attribute

--- a/src/NexusMods.MnemonicDB.Abstractions/TxFunctions/ExtensionMethods.cs
+++ b/src/NexusMods.MnemonicDB.Abstractions/TxFunctions/ExtensionMethods.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace NexusMods.MnemonicDB.Abstractions.TxFunctions;
+
+/// <summary>
+/// Extension methods for TxFunctions.
+/// </summary>
+public static class ExtensionMethods
+{
+    /// <summary>
+    /// Adds a function to the transaction as a TxFunction
+    /// </summary>
+    public static void Add<T>(this ITransaction tx, T arg, Action<ITransaction, IDb, T> fn) =>
+        tx.Add(new TxFunction<T>(fn, arg));
+
+    /// <summary>
+    /// Adds a function to the transaction as a TxFunction
+    /// </summary>
+    public static void Add<TA, TB>(this ITransaction tx, TA a, TB b, Action<ITransaction, IDb, TA, TB> fn) =>
+        tx.Add(new TxFunction<TA, TB>(fn, a, b));
+}

--- a/src/NexusMods.MnemonicDB.Abstractions/TxFunctions/ITxFunction.cs
+++ b/src/NexusMods.MnemonicDB.Abstractions/TxFunctions/ITxFunction.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace NexusMods.MnemonicDB.Abstractions.TxFunctions;
+
+/// <summary>
+/// Defines a transactor function. These are functions that are applied inside the guts
+/// of the `Log` function of the `DatomStore`. They are executed serially and are used
+/// to maintain consistency of the database when absolutely require. They are not designed
+/// for general use and should be used sparingly as they are essentially single-threaded
+/// </summary>
+public interface ITxFunction : IEquatable<ITxFunction>
+{
+    /// <summary>
+    /// Tells the function to add datoms to the transaction. The most recent copy of the database
+    /// is provided as a basis for the function to work on. Functions cannot see the results of
+    /// other functions in the same transaction.
+    /// </summary>
+    public void Apply(ITransaction tx, IDb basis);
+}

--- a/src/NexusMods.MnemonicDB.Abstractions/TxFunctions/TxFunction.cs
+++ b/src/NexusMods.MnemonicDB.Abstractions/TxFunctions/TxFunction.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace NexusMods.MnemonicDB.Abstractions.TxFunctions;
+
+/// <summary>
+/// A function that can be applied to a transaction, that takes a single argument.
+/// </summary>
+public record TxFunction<T>(Action<ITransaction, IDb, T> Fn, T val) : ITxFunction
+{
+    /// <inheritdoc />
+    public void Apply(ITransaction tx, IDb basis) => Fn(tx, basis, val);
+
+    /// <inheritdoc />
+    public virtual bool Equals(ITxFunction? other)
+    {
+        if (ReferenceEquals(null, other)) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return other is TxFunction<T> function && Equals(function);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Fn, val);
+    }
+}
+
+
+/// <summary>
+/// A function that can be applied to a transaction, that takes a single argument.
+/// </summary>
+public record TxFunction<TA, TB>(Action<ITransaction, IDb, TA, TB> Fn, TA A, TB B) : ITxFunction
+{
+    /// <inheritdoc />
+    public void Apply(ITransaction tx, IDb basis) => Fn(tx, basis, A, B);
+
+    /// <inheritdoc />
+    public virtual bool Equals(ITxFunction? other)
+    {
+        if (ReferenceEquals(null, other)) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return other is TxFunction<TA, TB> function && Equals(function);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Fn, A, B);
+    }
+}

--- a/src/NexusMods.MnemonicDB.Storage/DatomStorageStructures/PendingTransaction.cs
+++ b/src/NexusMods.MnemonicDB.Storage/DatomStorageStructures/PendingTransaction.cs
@@ -1,6 +1,9 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.MnemonicDB.Abstractions.IndexSegments;
+using NexusMods.MnemonicDB.Abstractions.TxFunctions;
 
 namespace NexusMods.MnemonicDB.Storage.DatomStorageStructures;
 
@@ -19,4 +22,15 @@ internal class PendingTransaction
     ///     The data to be commited
     /// </summary>
     public required IndexSegment Data { get; init; }
+
+    /// <summary>
+    ///     Tx functions to be applied to the transaction, if any
+    /// </summary>
+    public required HashSet<ITxFunction>? TxFunctions { get; init; }
+
+    /// <summary>
+    ///     A function for creating a new database instance from a given snapshot. Not required
+    /// if TxFunctions is null.
+    /// </summary>
+    public required Func<ISnapshot, IDb>? DatabaseFactory { get; init; }
 }

--- a/src/NexusMods.MnemonicDB.Storage/InternalTransaction.cs
+++ b/src/NexusMods.MnemonicDB.Storage/InternalTransaction.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NexusMods.MnemonicDB.Abstractions;
+using NexusMods.MnemonicDB.Abstractions.IndexSegments;
+using NexusMods.MnemonicDB.Abstractions.TxFunctions;
+
+namespace NexusMods.MnemonicDB.Storage;
+
+internal class InternalTransaction(IndexSegmentBuilder datoms) : ITransaction
+{
+    private ulong _tempId = Ids.MinId(Ids.Partition.Tmp) + 1;
+
+    /// <inheritdoc />
+    public TxId ThisTxId => TxId.From(Ids.MinId(Ids.Partition.Tmp));
+
+
+    /// <inhertdoc />
+    public EntityId TempId(byte entityPartition = (byte)Ids.Partition.Entity)
+    {
+        var tempId = Interlocked.Increment(ref _tempId);
+        // Add the partition to the id
+        var actualId = ((ulong)entityPartition << 40) | tempId;
+        return EntityId.From(actualId);
+    }
+
+    /// <inheritdoc />
+    public void Add<TVal, TLowLevel>(EntityId entityId, Attribute<TVal, TLowLevel> attribute, TVal val, bool isRetract = false)
+    {
+        datoms.Add(entityId, attribute, val, ThisTxId, isRetract);
+    }
+
+    /// <inheritdoc />
+    public void Add(ITxFunction fn)
+    {
+        throw new NotSupportedException();
+    }
+
+    /// <inheritdoc />
+    public Task<ICommitResult> Commit()
+    {
+        throw new NotSupportedException();
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+    }
+
+
+}


### PR DESCRIPTION
Adds TxFunctions which are a way to get serialized updates to entities, that are issued in a parallel manner. Essentially we package a function (a closure) in as part of the transaction, and that function is run with the context of the single threaded writer. This can be used to get atomic updates to values. Simply reading a value, incrementing it and writing that as a transaction would result in race conditions. So instead we ship over a Tx function and have it increment the value. 

I need this as part of my changes to the app to support a `.Revsion` value on Loadouts/Mods to trigger updates in the UI. Based on this logic, when we update a file we can tigger a revision update on the mods of that file as well as the loadout its in. 