### PR TITLE
Adds marker attributes

### DIFF
--- a/src/NexusMods.MnemonicDB.Abstractions/Attributes/MarkerAttribute.cs
+++ b/src/NexusMods.MnemonicDB.Abstractions/Attributes/MarkerAttribute.cs
@@ -1,0 +1,44 @@
+﻿using NexusMods.MnemonicDB.Abstractions.ElementComparers;
+using NexusMods.MnemonicDB.Abstractions.Models;
+
+namespace NexusMods.MnemonicDB.Abstractions.Attributes;
+
+/// <summary>
+/// An attribute that doesn't have a value, but is used to dispatch logic or to mark an entity
+/// as being of a certain type.
+/// </summary>
+/// <param name="ns"></param>
+/// <param name="name"></param>
+public class MarkerAttribute(string ns, string name) : Attribute<Null, Null>(ValueTags.Null, ns, name)
+{
+    /// <inheritdoc />
+    protected override Null ToLowLevel(Null value)
+    {
+        return value;
+    }
+
+    /// <summary>
+    /// Add the attribute to the entity.
+    /// </summary>
+    /// <param name="entityWithTx"></param>
+    public void Add(IEntityWithTx entityWithTx)
+    {
+        Add(entityWithTx, new Null());
+    }
+
+    /// <summary>
+    /// Returns true if the entity contains the attribute.
+    /// </summary>
+    public bool Contains(IEntity entity)
+    {
+        var segment = entity.Db.Get(entity.Id);
+        var dbId = Cache[segment.RegistryId.Value];
+        for (var i = 0; i < segment.Count; i++)
+        {
+            var datom = segment[i];
+            if (datom.A != dbId) continue;
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/NexusMods.MnemonicDB.Abstractions/ElementComparers/Null.cs
+++ b/src/NexusMods.MnemonicDB.Abstractions/ElementComparers/Null.cs
@@ -1,0 +1,10 @@
+﻿namespace NexusMods.MnemonicDB.Abstractions.ElementComparers;
+
+/// <summary>
+/// A null value, used to represent a null as a value. This is mostly used for
+/// marker attributes that don't have a value.
+/// </summary>
+public struct Null
+{
+
+}

--- a/src/NexusMods.MnemonicDB.Abstractions/Models/TempEntity.cs
+++ b/src/NexusMods.MnemonicDB.Abstractions/Models/TempEntity.cs
@@ -1,6 +1,9 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using DynamicData;
+using NexusMods.MnemonicDB.Abstractions.Attributes;
+using NexusMods.MnemonicDB.Abstractions.ElementComparers;
 
 namespace NexusMods.MnemonicDB.Abstractions.Models;
 
@@ -23,13 +26,20 @@ public class TempEntity : IEnumerable<(IAttribute, object)>
         _members.Add((attribute, value!));
     }
 
-
     /// <summary>
     /// Adds an attribute/value to the entity.
     /// </summary>
     public void Add(IAttribute<EntityId> attribute, TempEntity value)
     {
         _members.Add((attribute, value));
+    }
+
+    /// <summary>
+    /// Adds a marker attribute to the entity.
+    /// </summary>
+    public void Add(MarkerAttribute attr)
+    {
+        _members.Add((attr, new Null()));
     }
 
     /// <summary>

--- a/tests/NexusMods.MnemonicDB.TestModel/Mod.cs
+++ b/tests/NexusMods.MnemonicDB.TestModel/Mod.cs
@@ -14,6 +14,11 @@ public static class Mod
     public static readonly UriAttribute Source = new(Namespace, "Source");
     public static readonly ReferenceAttribute LoadoutId = new(Namespace, "Loadout");
 
+    /// <summary>
+    /// Test attribute for testing marker attributes.
+    /// </summary>
+    public static readonly MarkerAttribute IsMarked = new(Namespace, "IsMarked");
+
     public class Model(ITransaction tx) : Entity(tx)
     {
         public string Name
@@ -26,6 +31,11 @@ public static class Mod
         {
             get => Mod.Source.Get(this);
             init => Mod.Source.Add(this, value);
+        }
+        public bool IsMarked
+        {
+            get => Mod.IsMarked.Contains(this);
+            set => Mod.IsMarked.Add(this);
         }
 
         public EntityId LoadoutId

--- a/tests/NexusMods.MnemonicDB.Tests/DbTests.cs
+++ b/tests/NexusMods.MnemonicDB.Tests/DbTests.cs
@@ -364,6 +364,24 @@ public class DbTests(IServiceProvider provider) : AMnemonicDBTest(provider)
     }
 
     [Fact]
+    public async Task CanWorkWithMarkerAttributes()
+    {
+        var mod = new TempEntity
+        {
+            { Mod.Name, "Test Mod" },
+            Mod.IsMarked,
+        };
+
+        using var tx = Connection.BeginTransaction();
+        mod.AddTo(tx);
+        var result = await tx.Commit();
+
+        var reloaded = result.Db.Get<Mod.Model>(result[mod.Id!.Value]);
+        reloaded.IsMarked.Should().BeTrue();
+
+    }
+
+    [Fact]
     public async Task CanExecuteTxFunctions()
     {
         EntityId id;


### PR DESCRIPTION
Adds `MarkerAttribute` for cases where attributes don't have an explicit meaningful value, and we just want the existance of the attribute to indicate a true/false value. Gets rid of the tri-state issue of a boolean attribute of: what's the difference between Foo doesn't exist vs Foo = false?