### PR TITLE
Fix bug with RefCount and ObservableDatoms

### DIFF
--- a/src/NexusMods.MnemonicDB.Abstractions/Query/ObservableDatoms.cs
+++ b/src/NexusMods.MnemonicDB.Abstractions/Query/ObservableDatoms.cs
@@ -49,7 +49,7 @@ public static class ObservableDatoms
         {
             lock (set)
             {
-                if (rev.BasisTxId <= lastTxId)
+                if (rev.BasisTxId <= lastTxId && idx != 0)
                     return ChangeSet<Datom>.Empty;
 
                 lastTxId = rev.BasisTxId;

--- a/tests/NexusMods.MnemonicDB.Tests/DbTests.RefCountWorksWithObservables.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Tests/DbTests.RefCountWorksWithObservables.verified.txt
@@ -1,0 +1,5 @@
+﻿[
+  Test Mod,
+  Test Mod 2,
+  Test Mod 3
+]


### PR DESCRIPTION
The key change here is that we use `.Select((itm, idx) =>)` to know when we are at the start of the observable. However we also deduplicate identical DBs. When a RefCount restarts we get a `idx` of `0` as we should, but we get the same DB again, and so the `0` was being filtered out, so we weren't re-priming the datasets causing this error