### PR TITLE
Behavior subject fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## Changelog
 
-### 0.9.81 - 19/09/2024
+### 0.9.82 - 12/09/2024
+* Fix a O(n) issue caused by Rx storing observers in a ImmutableList inside a `BehaviorSubject`. Switched to using R3 internally. Over 
+time Rx's uses will be replaced with R3 to avoid these and several other issues
+
+### 0.9.81 - 9/09/2024
 * Fix a bug the source generators when trying to use HashedBlobAttributes
 
 ### 0.9.80 - 22/08/2024

--- a/src/NexusMods.MnemonicDB.Abstractions/IDatomStore.cs
+++ b/src/NexusMods.MnemonicDB.Abstractions/IDatomStore.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Tasks;
 using NexusMods.MnemonicDB.Abstractions.IndexSegments;
 using NexusMods.MnemonicDB.Abstractions.Internals;
 using NexusMods.MnemonicDB.Abstractions.TxFunctions;
+using R3;
 
 namespace NexusMods.MnemonicDB.Abstractions;
 
@@ -17,7 +17,7 @@ public interface IDatomStore : IDisposable
     ///     An observable of the transaction log, for getting the latest changes to the store. This observable
     /// will always start with the most recent value, so there is no reason to use `StartWith` or `Replay` on it.
     /// </summary>
-    public IObservable<IDb> TxLog { get; }
+    public Observable<IDb> TxLog { get; }
 
     /// <summary>
     ///     Gets the latest transaction id found in the log.

--- a/src/NexusMods.MnemonicDB.Abstractions/NexusMods.MnemonicDB.Abstractions.csproj
+++ b/src/NexusMods.MnemonicDB.Abstractions/NexusMods.MnemonicDB.Abstractions.csproj
@@ -8,6 +8,7 @@
         <PackageReference Include="DynamicData" Version="8.4.1"/>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1"/>
         <PackageReference Include="NexusMods.Paths" Version="0.9.5" />
+        <PackageReference Include="R3" Version="1.2.8" />
         <PackageReference Include="System.IO.Hashing" Version="8.0.0" />
         <PackageReference Include="TransparentValueObjects" Version="1.0.1" PrivateAssets="all" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>
         <PackageReference Update="JetBrains.Annotations" Version="2023.3.0"/>

--- a/src/NexusMods.MnemonicDB/NexusMods.MnemonicDB.csproj
+++ b/src/NexusMods.MnemonicDB/NexusMods.MnemonicDB.csproj
@@ -7,6 +7,7 @@
         <PackageReference Include="DynamicData" Version="8.4.1"/>
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1"/>
         <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.6" />
+        <PackageReference Include="R3" Version="1.2.8" />
         <PackageReference Include="Reloaded.Memory" Version="9.4.1"/>
         <PackageReference Include="RocksDB" Version="8.11.3.46984" />
         <PackageReference Include="System.Reactive" Version="6.0.1" />

--- a/src/NexusMods.MnemonicDB/Storage/DatomStore.cs
+++ b/src/NexusMods.MnemonicDB/Storage/DatomStore.cs
@@ -3,7 +3,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Reactive.Subjects;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,6 +17,7 @@ using NexusMods.MnemonicDB.Abstractions.Query;
 using NexusMods.MnemonicDB.Abstractions.TxFunctions;
 using NexusMods.MnemonicDB.Storage.Abstractions;
 using NexusMods.MnemonicDB.Storage.DatomStorageStructures;
+using R3;
 using Reloaded.Memory.Extensions;
 
 namespace NexusMods.MnemonicDB.Storage;
@@ -158,7 +158,7 @@ public class DatomStore : IDatomStore
     }
     
     /// <inheritdoc />
-    public IObservable<IDb> TxLog
+    public Observable<IDb> TxLog
     {
         get
         {


### PR DESCRIPTION
The guts of Rx's `BehaviorSubject` bottoms out at this

```csharp
        private void Unsubscribe(IObserver<T> observer)
        {
            lock (_gate)
            {
                if (!_isDisposed)
                {
                    _observers = _observers.Remove(observer);
                }
            }
        }
```

So yeah, you better hope you don't have a lot of observers on the subject because when they dispose it's a O(n) scan. Replaced the guts of the reactive code in MnemonicDB with R3's variant which are much faster and use array pools, index based removal and a lot of similar features.