### PR TITLE
Faster subscriptions

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
         <Nullable>enable</Nullable>
-        <LangVersion>12</LangVersion>
+        <LangVersion>13</LangVersion>
         <ImplicitUsings>false</ImplicitUsings>
         <WarningsAsErrors>Nullable</WarningsAsErrors>
         <TargetFramework>net9.0</TargetFramework>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,6 +1,7 @@
 <Project>
   <ItemGroup>
     <PackageVersion Include="DynamicData" Version="9.0.4" />
+    <PackageVersion Include="Jamarino.IntervalTree" Version="1.2.2" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="9.0.0" />

--- a/src/NexusMods.MnemonicDB.Abstractions/Datom.cs
+++ b/src/NexusMods.MnemonicDB.Abstractions/Datom.cs
@@ -9,7 +9,7 @@ namespace NexusMods.MnemonicDB.Abstractions.DatomIterators;
 /// Represents a raw (unparsed) datom from an index. Most of the time this datom is only valid for the
 /// lifetime of the current iteration. It is not safe to store this datom for later use.
 /// </summary>
-public readonly struct Datom : IEquatable<Datom>
+public readonly struct Datom : IEquatable<Datom>, IComparable<Datom>
 {
     private readonly KeyPrefix _prefix;
     private readonly ReadOnlyMemory<byte> _valueBlob;
@@ -159,5 +159,11 @@ public readonly struct Datom : IEquatable<Datom>
     public override int GetHashCode()
     {
         return HashCode.Combine(_prefix.GetHashCode());
+    }
+
+    /// <inheritdoc />
+    public int CompareTo(Datom other)
+    {
+        return Compare(other);
     }
 }

--- a/src/NexusMods.MnemonicDB.Abstractions/IConnection.cs
+++ b/src/NexusMods.MnemonicDB.Abstractions/IConnection.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using DynamicData;
+using NexusMods.MnemonicDB.Abstractions.DatomIterators;
 using NexusMods.MnemonicDB.Abstractions.IndexSegments;
 using NexusMods.MnemonicDB.Abstractions.Internals;
+using NexusMods.MnemonicDB.Abstractions.Query;
 
 namespace NexusMods.MnemonicDB.Abstractions;
 
@@ -77,4 +80,10 @@ public interface IConnection
     /// Update the database's schema with the given attributes.
     /// </summary>
     public Task UpdateSchema(params IAttribute[] attribute);
+
+    /// <summary>
+    /// Observe a slice of the database, as datoms are added or removed from the database, the observer will be updated
+    /// with the changeset of datoms that have been added or removed.
+    /// </summary>
+    IObservable<IChangeSet<Datom, DatomKey>> ObserveDatoms(SliceDescriptor descriptor);
 }

--- a/src/NexusMods.MnemonicDB.Abstractions/Query/ObservableDatoms.cs
+++ b/src/NexusMods.MnemonicDB.Abstractions/Query/ObservableDatoms.cs
@@ -41,6 +41,7 @@ public static class ObservableDatoms
     /// Observe a slice of the database, as datoms are added or removed from the database, the observer will be updated
     /// with the changeset of datoms that have been added or removed.
     /// </summary>
+    /*
     public static IObservable<IChangeSet<Datom, DatomKey>> ObserveDatoms(this IConnection conn, SliceDescriptor descriptor)
     {
         var lastTxId = TxId.From(0);
@@ -58,7 +59,7 @@ public static class ObservableDatoms
                 return Setup(rev, descriptor);
             return Diff(conn.AttributeCache, rev.RecentlyAdded, descriptor);
         });
-    }
+    }*/
 
     /// <summary>
     /// Observe all datoms for a given entity id

--- a/src/NexusMods.MnemonicDB/Connection.cs
+++ b/src/NexusMods.MnemonicDB/Connection.cs
@@ -2,13 +2,19 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using DynamicData;
+using Jamarino.IntervalTree;
 using Microsoft.Extensions.Logging;
 using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.MnemonicDB.Abstractions.BuiltInEntities;
+using NexusMods.MnemonicDB.Abstractions.DatomIterators;
 using NexusMods.MnemonicDB.Abstractions.ElementComparers;
 using NexusMods.MnemonicDB.Abstractions.IndexSegments;
+using NexusMods.MnemonicDB.Abstractions.Query;
 using NexusMods.MnemonicDB.InternalTxFunctions;
 using NexusMods.MnemonicDB.Storage;
 
@@ -25,6 +31,18 @@ public class Connection : IConnection
     private DbStream _dbStream;
     private IDisposable? _dbStreamDisposable;
     private readonly IAnalyzer[] _analyzers;
+    
+    // Temporary storage for processing observers, we store these in the class so we don't have to 
+    // allocate them on each update, and the code that uses these is always run on the same thread.
+    private readonly LightIntervalTree<Datom, Subject<IChangeSet<Datom, DatomKey>>> _datomObservers = new();
+    private readonly Dictionary<Subject<IChangeSet<Datom, DatomKey>>, ChangeSet<Datom, DatomKey>> _changeSets = new();
+    private readonly List<Change<Datom, DatomKey>> _localChanges = [];
+    
+    private static readonly IndexType[] IndexTypes =
+    [
+        IndexType.EAVTCurrent, IndexType.AEVTCurrent, IndexType.VAETCurrent, IndexType.AVETCurrent,
+        IndexType.TxLog
+    ];
 
     /// <summary>
     ///     Main connection class, co-ordinates writes and immutable reads
@@ -65,10 +83,97 @@ public class Connection : IConnection
                     _logger.LogError(ex, "Failed to analyze with {Analyzer}", analyzer.GetType().Name);
                 }
             }
+            
+            _dbStream.OnNext(db);
+            ProcessObservers(db);
             prev = idb;
+            
 
             return idb;
         });
+    }
+
+    private void ProcessObservers(Db db)
+    {
+        lock (_datomObservers)
+        {
+            var recentlyAdded = db.RecentlyAdded;
+            var cache = db.AttributeCache;
+            _changeSets.Clear();
+            
+            // For each recently added datom, we need to find listeners to it
+            for (var i = 0; i < recentlyAdded.Count; i++)
+            {
+                // We're going to add changes to this list, and then send them all at the end
+                _localChanges.Clear();
+                
+                var datom = recentlyAdded[i];
+                
+                var isMany = cache.IsCardinalityMany(datom.A);
+                var attr = datom.A;
+                if (datom.IsRetract)
+                {
+                    
+                    // If the attribute is cardinality many, we can just remove the datom
+                    if (isMany)
+                    {
+                        _localChanges.Add(new Change<Datom, DatomKey>(ChangeReason.Remove, CreateKey(datom, attr, true), datom));
+                        goto PROCESS_CHANGES;
+                    }
+                    
+                    // If at the end of the segment
+                    if (i + 1 >= recentlyAdded.Count)
+                    {
+                        _localChanges.Add(new Change<Datom, DatomKey>(ChangeReason.Remove, CreateKey(datom, attr), datom));
+                        goto PROCESS_CHANGES;
+                    }
+
+                    // If the next datom is not the same E or A, we can remove the datom
+                    var nextDatom = recentlyAdded[i + 1];
+                    if (nextDatom.E != datom.E || nextDatom.A != datom.A)
+                    {
+                        _localChanges.Add(new Change<Datom, DatomKey>(ChangeReason.Remove, CreateKey(datom, attr), datom));
+                        goto PROCESS_CHANGES;
+                    }
+
+                    // Otherwise we skip the add, and issue an update, and skip the add because we've already processed it
+                    _localChanges.Add(new Change<Datom, DatomKey>(ChangeReason.Update, CreateKey(datom, attr), nextDatom, datom));
+                    i++;
+                }
+                else
+                {
+                    _localChanges.Add(new Change<Datom, DatomKey>(ChangeReason.Add, CreateKey(datom, attr, isMany), datom));
+                }
+
+                // Yes, I know this is a goto, but we need a way to run some code at the end of each loop after we early exit
+                // from the if-tree above.
+                PROCESS_CHANGES:
+                
+                // Now that we've found all the changes, we need to find all the observers that are interested in this datom
+                
+                // We could likely be cleaner about how we do this, but this will work for now
+                foreach (var index in IndexTypes)
+                {
+                    var reindex = datom.WithIndex(index);
+                    foreach (var overlap in _datomObservers.Query(reindex))
+                    {
+                        if (!_changeSets.TryGetValue(overlap, out var changeSet))
+                        {
+                            changeSet = [];
+                            _changeSets.Add(overlap, changeSet);
+                        }
+
+                        changeSet.AddRange(_localChanges);
+                    }
+                }
+            }
+            
+            // Release all the sends
+            foreach (var (subject, changeSet) in _changeSets)
+            {
+                subject.OnNext(changeSet);
+            }
+        }
     }
 
     /// <inheritdoc />
@@ -148,6 +253,39 @@ public class Connection : IConnection
         return Transact(new SchemaMigration(attribute));
     }
 
+    public IObservable<IChangeSet<Datom, DatomKey>> ObserveDatoms(SliceDescriptor descriptor)
+    {
+        var subject = new Subject<IChangeSet<Datom, DatomKey>>();
+
+        lock (_datomObservers)
+        {
+            var fromDatom = descriptor.From.WithIndex(descriptor.Index);
+            var toDatom = descriptor.To.WithIndex(descriptor.Index);
+            _datomObservers.Add(fromDatom, toDatom, subject);
+
+            var db = Db;
+            var datoms = db.Datoms(descriptor);
+            var cache = db.AttributeCache;
+            var changes = new ChangeSet<Datom, DatomKey>();
+            
+            foreach (var datom in datoms)
+            {
+                var isMany = cache.IsCardinalityMany(datom.A);
+                changes.Add(new Change<Datom, DatomKey>(ChangeReason.Add, CreateKey(datom, datom.A, isMany), datom));
+            }
+
+            if (changes.Count == 0)
+                return subject.StartWith(ChangeSet<Datom, DatomKey>.Empty);
+            return subject.StartWith(changes);
+        }
+    }
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static DatomKey CreateKey(Datom datom, AttributeId attrId, bool isMany = false)
+    {
+        return new DatomKey(datom.E, attrId, isMany ? datom.ValueMemory : Memory<byte>.Empty);
+    }
+
     /// <inheritdoc />
     public IObservable<IDb> Revisions => _dbStream;
     
@@ -177,7 +315,7 @@ public class Connection : IConnection
             _store.Transact(new SchemaMigration(declaredAttributes));
             
             _dbStreamDisposable = ProcessUpdates(_store.TxLog)
-                .Subscribe(itm => _dbStream.OnNext(itm));
+                .Subscribe();
         }
         catch (Exception ex)
         {

--- a/src/NexusMods.MnemonicDB/Connection.cs
+++ b/src/NexusMods.MnemonicDB/Connection.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using DynamicData;
@@ -157,12 +158,8 @@ public class Connection : IConnection
                     var reindex = datom.WithIndex(index);
                     foreach (var overlap in _datomObservers.Query(reindex))
                     {
-                        if (!_changeSets.TryGetValue(overlap, out var changeSet))
-                        {
-                            changeSet = [];
-                            _changeSets.Add(overlap, changeSet);
-                        }
-
+                        ref var changeSet = ref CollectionsMarshal.GetValueRefOrAddDefault(_changeSets, overlap, out _);
+                        changeSet ??= [];
                         changeSet.AddRange(_localChanges);
                     }
                 }

--- a/src/NexusMods.MnemonicDB/NexusMods.MnemonicDB.csproj
+++ b/src/NexusMods.MnemonicDB/NexusMods.MnemonicDB.csproj
@@ -6,6 +6,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="DynamicData"/>
+        <PackageReference Include="Jamarino.IntervalTree" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions"/>
         <PackageReference Include="Microsoft.Extensions.ObjectPool"/>

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/NullConnection.cs
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/NullConnection.cs
@@ -1,5 +1,8 @@
+using DynamicData;
 using NexusMods.MnemonicDB.Abstractions;
+using NexusMods.MnemonicDB.Abstractions.DatomIterators;
 using NexusMods.MnemonicDB.Abstractions.Internals;
+using NexusMods.MnemonicDB.Abstractions.Query;
 
 namespace NexusMods.MnemonicDB.Storage.Tests;
 
@@ -35,6 +38,11 @@ public class NullConnection : IConnection
     }
 
     public Task UpdateSchema(params IAttribute[] attribute)
+    {
+        throw new NotSupportedException();
+    }
+
+    public IObservable<IChangeSet<Datom, DatomKey>> ObserveDatoms(SliceDescriptor descriptor)
     {
         throw new NotSupportedException();
     }


### PR DESCRIPTION
Having a large number of subscriptions was causing a pathalogical slowdown on `conn.ObserveDatoms`. This was because every observable was providing a filter (and a subscription) on the diffed datoms. The complexity was then O(m*n) where `m` is the number of datoms and `n` is the number of subscriptions. This complexity existed even if most subscriptions did not overlap. 

This change introduces a IntervalTree, for tracking subscription ranges. Think of it as a tree where they keys are `Start` and `End`. You can add a bunch of ranges to the tree, then probe the tree with a key value and get all the dictionary values who's key overlaps the probe. We use this to drastically reduce the amount of processing required for each update. 

In addition we build up all the changesets for all subscribers, then release them at one time. This allows us to reuse several scratch structures and perform large batch operations on the updates, instead of having to allocate a lot of temoprary data storage. 

200x perf improvement for 10k subscribers looking at 20k datoms. Likely a reduction in memory usage from this as well.