### PR TITLE
unique-attributes

### DIFF
--- a/src/NexusMods.MnemonicDB.Abstractions/Attribute.cs
+++ b/src/NexusMods.MnemonicDB.Abstractions/Attribute.cs
@@ -57,6 +57,9 @@ public abstract class Attribute<TValueType, TLowLevelType, TSerializer> :
 
     /// <inheritdoc />
     public bool IsIndexed { get; init; }
+    
+    /// <inheritdoc />
+    public bool IsUnique { get; init; }
 
     /// <inheritdoc />
     public bool NoHistory { get; init; }

--- a/src/NexusMods.MnemonicDB.Abstractions/AttributeCache.cs
+++ b/src/NexusMods.MnemonicDB.Abstractions/AttributeCache.cs
@@ -18,6 +18,7 @@ public sealed class AttributeCache
     private BitArray _isCardinalityMany;
     private BitArray _isReference;
     private BitArray _isIndexed;
+    private BitArray _isUnique;
     private Symbol[] _symbols;
     private ValueTag[] _valueTags;
     private BitArray _isNoHistory;
@@ -31,6 +32,7 @@ public sealed class AttributeCache
         _isCardinalityMany = new BitArray(maxId);
         _isReference = new BitArray(maxId);
         _isIndexed = new BitArray(maxId);
+        _isUnique = new BitArray(maxId);
         _isNoHistory = new BitArray(maxId);
         _symbols = new Symbol[maxId];
         _valueTags = new ValueTag[maxId];
@@ -39,6 +41,7 @@ public sealed class AttributeCache
         {
             _attributeIdsBySymbol[kv.Key.Id] = AttributeId.From(kv.Value);
             _isIndexed[kv.Value] = kv.Key.IsIndexed;
+            _isUnique[kv.Value] = kv.Key.IsUnique;
             _symbols[kv.Value] = kv.Key.Id;
             _valueTags[kv.Value] = kv.Key.LowLevelType;
         }
@@ -88,6 +91,15 @@ public sealed class AttributeCache
             newIsIndexed[(int)id] = true;
         }
         _isIndexed = newIsIndexed;
+        
+        var isUnique = db.Datoms(AttributeDefinition.Unique);
+        var newIsUnique = new BitArray(maxIndex);
+        foreach (var datom in isUnique)
+        {
+            var id = datom.E.Value;
+            newIsUnique[(int)id] = true;
+        }
+        _isUnique = newIsUnique;
         
         var isNoHistory = db.Datoms(AttributeDefinition.NoHistory);
         var newIsNoHistory = new BitArray(maxIndex);

--- a/src/NexusMods.MnemonicDB.Abstractions/AttributeCache.cs
+++ b/src/NexusMods.MnemonicDB.Abstractions/AttributeCache.cs
@@ -205,4 +205,12 @@ public sealed class AttributeCache
     {
         return _valueTags[aid.Value];
     }
+
+    /// <summary>
+    /// Returns true if the attribute is unique.
+    /// </summary>
+    public bool IsUnique(AttributeId attrId)
+    {
+        return _isUnique[attrId.Value];
+    }
 }

--- a/src/NexusMods.MnemonicDB.Abstractions/AttributeResolver.cs
+++ b/src/NexusMods.MnemonicDB.Abstractions/AttributeResolver.cs
@@ -14,7 +14,7 @@ namespace NexusMods.MnemonicDB.Abstractions;
 public sealed class AttributeResolver
 {
     private readonly FrozenDictionary<Symbol,IAttribute> _attrsById;
-    private AttributeCache _attributeCache;
+    private readonly AttributeCache _attributeCache;
 
     /// <summary>
     /// Occasionally we need to turn the raw datoms from the database into a IReadDatom, this class
@@ -25,6 +25,19 @@ public sealed class AttributeResolver
         ServiceProvider = provider;
         _attributeCache = cache;
         _attrsById = provider.GetServices<IAttribute>().ToDictionary(a => a.Id).ToFrozenDictionary();
+        
+        ValidateAttributes();
+    }
+
+    private void ValidateAttributes()
+    {
+        foreach (var attribute in _attrsById.Values)
+        {
+            if (attribute.IsUnique && !attribute.IsIndexed)
+            {
+                throw new InvalidOperationException($"Attribute {attribute.Id} is unique but not indexed, all unique attributes must also be indexed");
+            }
+        }
     }
 
 

--- a/src/NexusMods.MnemonicDB.Abstractions/BuiltInEntities/AttributeDefinition.cs
+++ b/src/NexusMods.MnemonicDB.Abstractions/BuiltInEntities/AttributeDefinition.cs
@@ -19,37 +19,42 @@ public partial class AttributeDefinition : IModelDefinition
     /// <summary>
     /// The unique identifier of the entity, used to link attributes across application restarts and model changes.
     /// </summary>
-    public static readonly SymbolAttribute UniqueId = new(Namespace, "UniqueId") { IsIndexed = true };
+    public static readonly SymbolAttribute UniqueId = new(Namespace, nameof(UniqueId)) { IsIndexed = true, IsUnique = true };
 
     /// <summary>
     /// The type of the value.
     /// </summary>
-    public static readonly ValuesTagAttribute ValueType = new(Namespace, "ValueType");
+    public static readonly ValuesTagAttribute ValueType = new(Namespace, nameof(ValueType));
 
     /// <summary>
     /// True if the attribute is indexed.
     /// </summary>
-    public static readonly MarkerAttribute Indexed = new(Namespace, "Indexed");
+    public static readonly MarkerAttribute Indexed = new(Namespace, nameof(Indexed));
+    
+    /// <summary>
+    /// True if the attribute is unique, that this attr/value pair can only exist on one entity at a time
+    /// </summary>
+    public static readonly MarkerAttribute Unique = new(Namespace, nameof(Unique));
 
     /// <summary>
     /// This attribute is optional.
     /// </summary>
-    public static readonly MarkerAttribute Optional = new(Namespace, "Optional");
+    public static readonly MarkerAttribute Optional = new(Namespace, nameof(Optional));
 
     /// <summary>
     /// Do not store history for this attribute.
     /// </summary>
-    public static readonly MarkerAttribute NoHistory = new(Namespace, "NoHistory");
+    public static readonly MarkerAttribute NoHistory = new(Namespace, nameof(NoHistory));
 
     /// <summary>
     /// The cardinality of the attribute.
     /// </summary>
-    public static readonly CardinalityAttribute Cardinality = new(Namespace, "Cardinality");
+    public static readonly CardinalityAttribute Cardinality = new(Namespace, nameof(Cardinality));
 
     /// <summary>
     /// The doc string for the attribute
     /// </summary>
-    public static readonly StringAttribute Documentation = new(Namespace, "Documentation") { IsOptional = true };
+    public static readonly StringAttribute Documentation = new(Namespace, nameof(Documentation)) { IsOptional = true };
 
     /// <summary>
     /// Inserts an attribute into the transaction.
@@ -64,6 +69,8 @@ public partial class AttributeDefinition : IModelDefinition
         tx.Add(eid, Cardinality, attribute.Cardinalty);
         if (attribute.IsIndexed)
             tx.Add(eid, Indexed, Null.Instance);
+        if (attribute.IsUnique)
+            tx.Add(eid, Unique, Null.Instance);
         if (attribute.NoHistory)
             tx.Add(eid, NoHistory, Null.Instance);
         if (attribute.DeclaredOptional)
@@ -82,7 +89,8 @@ public partial class AttributeDefinition : IModelDefinition
         { NoHistory, 5 },
         { Cardinality, 6 },
         { Documentation, 7 },
-        { Transaction.Timestamp, 8}
+        { Transaction.Timestamp, 8},
+        { Unique, 9 }
     };
     
     /// <summary>
@@ -94,6 +102,7 @@ public partial class AttributeDefinition : IModelDefinition
         Insert(tx, ValueType);
         Insert(tx, Documentation);
         Insert(tx, Indexed);
+        Insert(tx, Unique);
         Insert(tx, Optional);
         Insert(tx, NoHistory);
         Insert(tx, Cardinality);

--- a/src/NexusMods.MnemonicDB.Abstractions/IAttribute.cs
+++ b/src/NexusMods.MnemonicDB.Abstractions/IAttribute.cs
@@ -39,6 +39,12 @@ public interface IAttribute
     ///    True if the attribute is indexed, false if it is not.
     /// </summary>
     bool IsIndexed { get; }
+    
+    /// <summary>
+    ///    True if the attribute is unique, false if it is not. Unique here is global for a specific attribute, this can
+    /// be thought of as making sure that .Datoms(Attribute, Value) for this attribute never returns more than one datom.
+    /// </summary>
+    bool IsUnique { get; }
 
     /// <summary>
     ///   True if the attribute has no history, false if it does.

--- a/src/NexusMods.MnemonicDB.Abstractions/Query/SliceDescriptor.cs
+++ b/src/NexusMods.MnemonicDB.Abstractions/Query/SliceDescriptor.cs
@@ -338,4 +338,19 @@ public readonly struct SliceDescriptor
             To = Datom(eid, AttributeId.Max, TxId.MaxValue, false, indexType)
         };
     }
+
+    /// <summary>
+    /// Creates a new slice descriptor for the given reference attribute and prefix value tag
+    /// </summary>
+    public static SliceDescriptor Create(AttributeId referenceAttribute, ValueTag prefixValueTag, ReadOnlyMemory<byte> datomValueSpan)
+    {
+        var fromPrefix = new KeyPrefix(EntityId.MinValueNoPartition, referenceAttribute, TxId.MinValue, false, prefixValueTag, IndexType.AVETCurrent);
+        var toPrefix = new KeyPrefix(EntityId.MaxValueNoPartition, referenceAttribute, TxId.MaxValue, false, prefixValueTag, IndexType.AVETCurrent);
+
+        return new SliceDescriptor
+        {
+            From = new Datom(fromPrefix, datomValueSpan),
+            To = new Datom(toPrefix, datomValueSpan)
+        };
+    }
 }

--- a/src/NexusMods.MnemonicDB.Abstractions/UniqueConstraintException.cs
+++ b/src/NexusMods.MnemonicDB.Abstractions/UniqueConstraintException.cs
@@ -1,0 +1,9 @@
+using System;
+using NexusMods.MnemonicDB.Abstractions.DatomIterators;
+
+namespace NexusMods.MnemonicDB.Abstractions;
+
+/// <summary>
+/// Thrown when a unique constraint on a attribute is
+/// </summary>
+public class UniqueConstraintException(Datom datom) : Exception($"Unique constraint violation on datom: {datom}");

--- a/src/NexusMods.MnemonicDB/InternalTxFunctions/SimpleMigration.cs
+++ b/src/NexusMods.MnemonicDB/InternalTxFunctions/SimpleMigration.cs
@@ -53,6 +53,14 @@ internal class SimpleMigration : AInternalFn
                     RemoveIndex(store, aid, batch);
                 madeChanges = true;
             }
+
+            if (cache.IsUnique(aid) != attribute.IsUnique)
+            {
+                if (attribute.IsUnique)
+                    builder.Add(EntityId.From(aid.Value), AttributeDefinition.Unique, Null.Instance);
+                else
+                    builder.Add(EntityId.From(aid.Value), AttributeDefinition.Unique, Null.Instance, true);
+            }
             
             if (cache.GetValueTag(aid) != attribute.LowLevelType)
             {
@@ -78,6 +86,9 @@ internal class SimpleMigration : AInternalFn
         
         if (definition.IsIndexed) 
             builder.Add(id, AttributeDefinition.Indexed, Null.Instance);
+        
+        if (definition.IsUnique)
+            builder.Add(id, AttributeDefinition.Unique, Null.Instance);
         
         if (definition.DeclaredOptional)
             builder.Add(id, AttributeDefinition.Optional, Null.Instance);

--- a/src/NexusMods.MnemonicDB/UniqueAttributeEqualityComparer.cs
+++ b/src/NexusMods.MnemonicDB/UniqueAttributeEqualityComparer.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using NexusMods.MnemonicDB.Abstractions.DatomIterators;
+using NexusMods.MnemonicDB.Abstractions.ElementComparers;
+
+namespace NexusMods.MnemonicDB;
+
+/// <summary>
+/// A comparer that compares only the Attribute and Value of a Datom used for unique constraints.
+/// </summary>
+public class UniqueAttributeEqualityComparer : IComparer<Datom>
+{
+    /// <summary>
+    /// The global instance of the <see cref="UniqueAttributeEqualityComparer"/>.
+    /// </summary>
+    public static UniqueAttributeEqualityComparer Instance { get; } = new();
+
+
+    /// <inheritdoc />
+    public int Compare(Datom a, Datom b)
+    {
+        var cmp = AComparer.Compare(a, b);
+        if (cmp != 0)
+            return cmp;
+        
+        return ValueComparer.Compare(a, b);
+    }
+}

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.CanStoreDataInBlobs_type=AEVTCurrent.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.CanStoreDataInBlobs_type=AEVTCurrent.verified.txt
@@ -6,6 +6,7 @@
 + | 0000000000000006 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Cardinality      | 0100000000000001
 + | 0000000000000007 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Documentation    | 0100000000000001
 + | 0000000000000008 | (0001) UniqueId                 | NexusMods.MnemonicDB.Transaction/Timestamp       | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
 + | 0000000000000014 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Path         | 0100000000000002
 + | 0000000000000015 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Hash         | 0100000000000002
 + | 0000000000000016 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Size         | 0100000000000002
@@ -26,6 +27,7 @@
 + | 0000000000000006 | (0002) ValueType                | UInt8                                            | 0100000000000001
 + | 0000000000000007 | (0002) ValueType                | Utf8                                             | 0100000000000001
 + | 0000000000000008 | (0002) ValueType                | Int64                                            | 0100000000000001
++ | 0000000000000009 | (0002) ValueType                | Null                                             | 0100000000000001
 + | 0000000000000014 | (0002) ValueType                | Utf8Insensitive                                  | 0100000000000002
 + | 0000000000000015 | (0002) ValueType                | UInt64                                           | 0100000000000002
 + | 0000000000000016 | (0002) ValueType                | UInt64                                           | 0100000000000002
@@ -54,6 +56,7 @@
 + | 0000000000000006 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000007 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000008 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000009 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000014 | (0006) Cardinality              | 1                                                | 0100000000000002
 + | 0000000000000015 | (0006) Cardinality              | 1                                                | 0100000000000002
 + | 0000000000000016 | (0006) Cardinality              | 1                                                | 0100000000000002
@@ -74,6 +77,7 @@
 + | 0100000000000006 | (0008) Timestamp                | DateTime : 5                                     | 0100000000000006
 + | 0100000000000007 | (0008) Timestamp                | DateTime : 6                                     | 0100000000000007
 + | 0100000000000008 | (0008) Timestamp                | DateTime : 7                                     | 0100000000000008
++ | 0000000000000001 | (0009) Unique                   |                                                  | 0100000000000001
 + | 0200000000000003 | (001E) InKeyBlob                | Blob 0xB85FD37A0A050E63 255 bytes                | 0100000000000005
 + | 0200000000000004 | (001E) InKeyBlob                | Blob 0xB85FD37A0A050E63 255 bytes                | 0100000000000006
 + | 0200000000000003 | (001F) InValueBlob              | HashedBlob 0x8FFA0F9DFCB11153 16777216 bytes     | 0100000000000005

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.CanStoreDataInBlobs_type=AVETCurrent.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.CanStoreDataInBlobs_type=AVETCurrent.verified.txt
@@ -3,6 +3,7 @@
 + | 0000000000000003 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Indexed          | 0100000000000001
 + | 0000000000000005 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/NoHistory        | 0100000000000001
 + | 0000000000000004 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Optional         | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
 + | 0000000000000001 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/UniqueId         | 0100000000000001
 + | 0000000000000002 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/ValueType        | 0100000000000001
 + | 000000000000001E | (0001) UniqueId                 | NexusMods.MnemonicDB.S...stAttributes/InKeyBlob  | 0100000000000002

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.CanStoreDataInBlobs_type=EAVTCurrent.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.CanStoreDataInBlobs_type=EAVTCurrent.verified.txt
@@ -2,6 +2,7 @@
 + | 0000000000000001 | (0002) ValueType                | Ascii                                            | 0100000000000001
 + | 0000000000000001 | (0003) Indexed                  |                                                  | 0100000000000001
 + | 0000000000000001 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000001 | (0009) Unique                   |                                                  | 0100000000000001
 + | 0000000000000002 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/ValueType        | 0100000000000001
 + | 0000000000000002 | (0002) ValueType                | UInt8                                            | 0100000000000001
 + | 0000000000000002 | (0006) Cardinality              | 1                                                | 0100000000000001
@@ -24,6 +25,9 @@
 + | 0000000000000008 | (0001) UniqueId                 | NexusMods.MnemonicDB.Transaction/Timestamp       | 0100000000000001
 + | 0000000000000008 | (0002) ValueType                | Int64                                            | 0100000000000001
 + | 0000000000000008 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
++ | 0000000000000009 | (0002) ValueType                | Null                                             | 0100000000000001
++ | 0000000000000009 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000014 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Path         | 0100000000000002
 + | 0000000000000014 | (0002) ValueType                | Utf8Insensitive                                  | 0100000000000002
 + | 0000000000000014 | (0003) Indexed                  |                                                  | 0100000000000002

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.CanStoreDataInBlobs_type=TxLog.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.CanStoreDataInBlobs_type=TxLog.verified.txt
@@ -2,6 +2,7 @@
 + | 0000000000000001 | (0002) ValueType                | Ascii                                            | 0100000000000001
 + | 0000000000000001 | (0003) Indexed                  |                                                  | 0100000000000001
 + | 0000000000000001 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000001 | (0009) Unique                   |                                                  | 0100000000000001
 + | 0000000000000002 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/ValueType        | 0100000000000001
 + | 0000000000000002 | (0002) ValueType                | UInt8                                            | 0100000000000001
 + | 0000000000000002 | (0006) Cardinality              | 1                                                | 0100000000000001
@@ -24,6 +25,9 @@
 + | 0000000000000008 | (0001) UniqueId                 | NexusMods.MnemonicDB.Transaction/Timestamp       | 0100000000000001
 + | 0000000000000008 | (0002) ValueType                | Int64                                            | 0100000000000001
 + | 0000000000000008 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
++ | 0000000000000009 | (0002) ValueType                | Null                                             | 0100000000000001
++ | 0000000000000009 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0100000000000001 | (0008) Timestamp                | DateTime : 0                                     | 0100000000000001
 + | 0000000000000014 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Path         | 0100000000000002
 + | 0000000000000014 | (0002) ValueType                | Utf8Insensitive                                  | 0100000000000002

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.HistoricalQueriesReturnAllDataSorted_type=AEVTCurrent.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.HistoricalQueriesReturnAllDataSorted_type=AEVTCurrent.verified.txt
@@ -6,6 +6,7 @@
 + | 0000000000000006 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Cardinality      | 0100000000000001
 + | 0000000000000007 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Documentation    | 0100000000000001
 + | 0000000000000008 | (0001) UniqueId                 | NexusMods.MnemonicDB.Transaction/Timestamp       | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
 + | 0000000000000014 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Path         | 0100000000000002
 + | 0000000000000015 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Hash         | 0100000000000002
 + | 0000000000000016 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Size         | 0100000000000002
@@ -26,6 +27,7 @@
 + | 0000000000000006 | (0002) ValueType                | UInt8                                            | 0100000000000001
 + | 0000000000000007 | (0002) ValueType                | Utf8                                             | 0100000000000001
 + | 0000000000000008 | (0002) ValueType                | Int64                                            | 0100000000000001
++ | 0000000000000009 | (0002) ValueType                | Null                                             | 0100000000000001
 + | 0000000000000014 | (0002) ValueType                | Utf8Insensitive                                  | 0100000000000002
 + | 0000000000000015 | (0002) ValueType                | UInt64                                           | 0100000000000002
 + | 0000000000000016 | (0002) ValueType                | UInt64                                           | 0100000000000002
@@ -54,6 +56,7 @@
 + | 0000000000000006 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000007 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000008 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000009 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000014 | (0006) Cardinality              | 1                                                | 0100000000000002
 + | 0000000000000015 | (0006) Cardinality              | 1                                                | 0100000000000002
 + | 0000000000000016 | (0006) Cardinality              | 1                                                | 0100000000000002
@@ -70,6 +73,7 @@
 + | 0100000000000002 | (0008) Timestamp                | DateTime : 1                                     | 0100000000000002
 + | 0100000000000003 | (0008) Timestamp                | DateTime : 2                                     | 0100000000000003
 + | 0100000000000004 | (0008) Timestamp                | DateTime : 3                                     | 0100000000000004
++ | 0000000000000001 | (0009) Unique                   |                                                  | 0100000000000001
 + | 0200000000000001 | (0014) Path                     | /foo/bar                                         | 0100000000000003
 + | 0200000000000002 | (0014) Path                     | /foo/qux                                         | 0100000000000004
 + | 0200000000000002 | (0014) Path                     | /qix/bar                                         | 0100000000000003

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.HistoricalQueriesReturnAllDataSorted_type=AEVTHistory.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.HistoricalQueriesReturnAllDataSorted_type=AEVTHistory.verified.txt
@@ -6,6 +6,7 @@
 + | 0000000000000006 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Cardinality      | 0100000000000001
 + | 0000000000000007 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Documentation    | 0100000000000001
 + | 0000000000000008 | (0001) UniqueId                 | NexusMods.MnemonicDB.Transaction/Timestamp       | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
 + | 0000000000000014 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Path         | 0100000000000002
 + | 0000000000000015 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Hash         | 0100000000000002
 + | 0000000000000016 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Size         | 0100000000000002
@@ -26,6 +27,7 @@
 + | 0000000000000006 | (0002) ValueType                | UInt8                                            | 0100000000000001
 + | 0000000000000007 | (0002) ValueType                | Utf8                                             | 0100000000000001
 + | 0000000000000008 | (0002) ValueType                | Int64                                            | 0100000000000001
++ | 0000000000000009 | (0002) ValueType                | Null                                             | 0100000000000001
 + | 0000000000000014 | (0002) ValueType                | Utf8Insensitive                                  | 0100000000000002
 + | 0000000000000015 | (0002) ValueType                | UInt64                                           | 0100000000000002
 + | 0000000000000016 | (0002) ValueType                | UInt64                                           | 0100000000000002
@@ -54,6 +56,7 @@
 + | 0000000000000006 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000007 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000008 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000009 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000014 | (0006) Cardinality              | 1                                                | 0100000000000002
 + | 0000000000000015 | (0006) Cardinality              | 1                                                | 0100000000000002
 + | 0000000000000016 | (0006) Cardinality              | 1                                                | 0100000000000002
@@ -70,6 +73,7 @@
 + | 0100000000000002 | (0008) Timestamp                | DateTime : 1                                     | 0100000000000002
 + | 0100000000000003 | (0008) Timestamp                | DateTime : 2                                     | 0100000000000003
 + | 0100000000000004 | (0008) Timestamp                | DateTime : 3                                     | 0100000000000004
++ | 0000000000000001 | (0009) Unique                   |                                                  | 0100000000000001
 + | 0200000000000001 | (0014) Path                     | /foo/bar                                         | 0100000000000003
 + | 0200000000000002 | (0014) Path                     | /foo/qux                                         | 0100000000000004
 + | 0200000000000002 | (0014) Path                     | /qix/bar                                         | 0100000000000003

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.HistoricalQueriesReturnAllDataSorted_type=AVETCurrent.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.HistoricalQueriesReturnAllDataSorted_type=AVETCurrent.verified.txt
@@ -3,6 +3,7 @@
 + | 0000000000000003 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Indexed          | 0100000000000001
 + | 0000000000000005 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/NoHistory        | 0100000000000001
 + | 0000000000000004 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Optional         | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
 + | 0000000000000001 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/UniqueId         | 0100000000000001
 + | 0000000000000002 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/ValueType        | 0100000000000001
 + | 000000000000001E | (0001) UniqueId                 | NexusMods.MnemonicDB.S...stAttributes/InKeyBlob  | 0100000000000002

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.HistoricalQueriesReturnAllDataSorted_type=AVETHistory.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.HistoricalQueriesReturnAllDataSorted_type=AVETHistory.verified.txt
@@ -3,6 +3,7 @@
 + | 0000000000000003 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Indexed          | 0100000000000001
 + | 0000000000000005 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/NoHistory        | 0100000000000001
 + | 0000000000000004 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Optional         | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
 + | 0000000000000001 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/UniqueId         | 0100000000000001
 + | 0000000000000002 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/ValueType        | 0100000000000001
 + | 000000000000001E | (0001) UniqueId                 | NexusMods.MnemonicDB.S...stAttributes/InKeyBlob  | 0100000000000002

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.HistoricalQueriesReturnAllDataSorted_type=EAVTCurrent.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.HistoricalQueriesReturnAllDataSorted_type=EAVTCurrent.verified.txt
@@ -2,6 +2,7 @@
 + | 0000000000000001 | (0002) ValueType                | Ascii                                            | 0100000000000001
 + | 0000000000000001 | (0003) Indexed                  |                                                  | 0100000000000001
 + | 0000000000000001 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000001 | (0009) Unique                   |                                                  | 0100000000000001
 + | 0000000000000002 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/ValueType        | 0100000000000001
 + | 0000000000000002 | (0002) ValueType                | UInt8                                            | 0100000000000001
 + | 0000000000000002 | (0006) Cardinality              | 1                                                | 0100000000000001
@@ -24,6 +25,9 @@
 + | 0000000000000008 | (0001) UniqueId                 | NexusMods.MnemonicDB.Transaction/Timestamp       | 0100000000000001
 + | 0000000000000008 | (0002) ValueType                | Int64                                            | 0100000000000001
 + | 0000000000000008 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
++ | 0000000000000009 | (0002) ValueType                | Null                                             | 0100000000000001
++ | 0000000000000009 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000014 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Path         | 0100000000000002
 + | 0000000000000014 | (0002) ValueType                | Utf8Insensitive                                  | 0100000000000002
 + | 0000000000000014 | (0003) Indexed                  |                                                  | 0100000000000002

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.HistoricalQueriesReturnAllDataSorted_type=EAVTHistory.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.HistoricalQueriesReturnAllDataSorted_type=EAVTHistory.verified.txt
@@ -2,6 +2,7 @@
 + | 0000000000000001 | (0002) ValueType                | Ascii                                            | 0100000000000001
 + | 0000000000000001 | (0003) Indexed                  |                                                  | 0100000000000001
 + | 0000000000000001 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000001 | (0009) Unique                   |                                                  | 0100000000000001
 + | 0000000000000002 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/ValueType        | 0100000000000001
 + | 0000000000000002 | (0002) ValueType                | UInt8                                            | 0100000000000001
 + | 0000000000000002 | (0006) Cardinality              | 1                                                | 0100000000000001
@@ -24,6 +25,9 @@
 + | 0000000000000008 | (0001) UniqueId                 | NexusMods.MnemonicDB.Transaction/Timestamp       | 0100000000000001
 + | 0000000000000008 | (0002) ValueType                | Int64                                            | 0100000000000001
 + | 0000000000000008 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
++ | 0000000000000009 | (0002) ValueType                | Null                                             | 0100000000000001
++ | 0000000000000009 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000014 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Path         | 0100000000000002
 + | 0000000000000014 | (0002) ValueType                | Utf8Insensitive                                  | 0100000000000002
 + | 0000000000000014 | (0003) Indexed                  |                                                  | 0100000000000002

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.InsertedDatomsShowUpInTheIndex_type=AEVTCurrent.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.InsertedDatomsShowUpInTheIndex_type=AEVTCurrent.verified.txt
@@ -6,6 +6,7 @@
 + | 0000000000000006 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Cardinality      | 0100000000000001
 + | 0000000000000007 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Documentation    | 0100000000000001
 + | 0000000000000008 | (0001) UniqueId                 | NexusMods.MnemonicDB.Transaction/Timestamp       | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
 + | 0000000000000014 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Path         | 0100000000000002
 + | 0000000000000015 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Hash         | 0100000000000002
 + | 0000000000000016 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Size         | 0100000000000002
@@ -26,6 +27,7 @@
 + | 0000000000000006 | (0002) ValueType                | UInt8                                            | 0100000000000001
 + | 0000000000000007 | (0002) ValueType                | Utf8                                             | 0100000000000001
 + | 0000000000000008 | (0002) ValueType                | Int64                                            | 0100000000000001
++ | 0000000000000009 | (0002) ValueType                | Null                                             | 0100000000000001
 + | 0000000000000014 | (0002) ValueType                | Utf8Insensitive                                  | 0100000000000002
 + | 0000000000000015 | (0002) ValueType                | UInt64                                           | 0100000000000002
 + | 0000000000000016 | (0002) ValueType                | UInt64                                           | 0100000000000002
@@ -54,6 +56,7 @@
 + | 0000000000000006 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000007 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000008 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000009 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000014 | (0006) Cardinality              | 1                                                | 0100000000000002
 + | 0000000000000015 | (0006) Cardinality              | 1                                                | 0100000000000002
 + | 0000000000000016 | (0006) Cardinality              | 1                                                | 0100000000000002
@@ -70,6 +73,7 @@
 + | 0100000000000002 | (0008) Timestamp                | DateTime : 1                                     | 0100000000000002
 + | 0100000000000003 | (0008) Timestamp                | DateTime : 2                                     | 0100000000000003
 + | 0100000000000004 | (0008) Timestamp                | DateTime : 3                                     | 0100000000000004
++ | 0000000000000001 | (0009) Unique                   |                                                  | 0100000000000001
 + | 0200000000000001 | (0014) Path                     | /foo/bar                                         | 0100000000000003
 + | 0200000000000002 | (0014) Path                     | /foo/qux                                         | 0100000000000004
 + | 0200000000000001 | (0015) Hash                     | 0x00000000DEADBEEF                               | 0100000000000003

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.InsertedDatomsShowUpInTheIndex_type=AVETCurrent.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.InsertedDatomsShowUpInTheIndex_type=AVETCurrent.verified.txt
@@ -3,6 +3,7 @@
 + | 0000000000000003 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Indexed          | 0100000000000001
 + | 0000000000000005 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/NoHistory        | 0100000000000001
 + | 0000000000000004 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Optional         | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
 + | 0000000000000001 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/UniqueId         | 0100000000000001
 + | 0000000000000002 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/ValueType        | 0100000000000001
 + | 000000000000001E | (0001) UniqueId                 | NexusMods.MnemonicDB.S...stAttributes/InKeyBlob  | 0100000000000002

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.InsertedDatomsShowUpInTheIndex_type=EAVTCurrent.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.InsertedDatomsShowUpInTheIndex_type=EAVTCurrent.verified.txt
@@ -2,6 +2,7 @@
 + | 0000000000000001 | (0002) ValueType                | Ascii                                            | 0100000000000001
 + | 0000000000000001 | (0003) Indexed                  |                                                  | 0100000000000001
 + | 0000000000000001 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000001 | (0009) Unique                   |                                                  | 0100000000000001
 + | 0000000000000002 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/ValueType        | 0100000000000001
 + | 0000000000000002 | (0002) ValueType                | UInt8                                            | 0100000000000001
 + | 0000000000000002 | (0006) Cardinality              | 1                                                | 0100000000000001
@@ -24,6 +25,9 @@
 + | 0000000000000008 | (0001) UniqueId                 | NexusMods.MnemonicDB.Transaction/Timestamp       | 0100000000000001
 + | 0000000000000008 | (0002) ValueType                | Int64                                            | 0100000000000001
 + | 0000000000000008 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
++ | 0000000000000009 | (0002) ValueType                | Null                                             | 0100000000000001
++ | 0000000000000009 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000014 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Path         | 0100000000000002
 + | 0000000000000014 | (0002) ValueType                | Utf8Insensitive                                  | 0100000000000002
 + | 0000000000000014 | (0003) Indexed                  |                                                  | 0100000000000002

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.InsertedDatomsShowUpInTheIndex_type=TxLog.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.InsertedDatomsShowUpInTheIndex_type=TxLog.verified.txt
@@ -2,6 +2,7 @@
 + | 0000000000000001 | (0002) ValueType                | Ascii                                            | 0100000000000001
 + | 0000000000000001 | (0003) Indexed                  |                                                  | 0100000000000001
 + | 0000000000000001 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000001 | (0009) Unique                   |                                                  | 0100000000000001
 + | 0000000000000002 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/ValueType        | 0100000000000001
 + | 0000000000000002 | (0002) ValueType                | UInt8                                            | 0100000000000001
 + | 0000000000000002 | (0006) Cardinality              | 1                                                | 0100000000000001
@@ -24,6 +25,9 @@
 + | 0000000000000008 | (0001) UniqueId                 | NexusMods.MnemonicDB.Transaction/Timestamp       | 0100000000000001
 + | 0000000000000008 | (0002) ValueType                | Int64                                            | 0100000000000001
 + | 0000000000000008 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
++ | 0000000000000009 | (0002) ValueType                | Null                                             | 0100000000000001
++ | 0000000000000009 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0100000000000001 | (0008) Timestamp                | DateTime : 0                                     | 0100000000000001
 + | 0000000000000014 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Path         | 0100000000000002
 + | 0000000000000014 | (0002) ValueType                | Utf8Insensitive                                  | 0100000000000002

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.RetractedValuesAreSupported_type=AEVTCurrent.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.RetractedValuesAreSupported_type=AEVTCurrent.verified.txt
@@ -6,6 +6,7 @@
 + | 0000000000000006 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Cardinality      | 0100000000000001
 + | 0000000000000007 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Documentation    | 0100000000000001
 + | 0000000000000008 | (0001) UniqueId                 | NexusMods.MnemonicDB.Transaction/Timestamp       | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
 + | 0000000000000014 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Path         | 0100000000000002
 + | 0000000000000015 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Hash         | 0100000000000002
 + | 0000000000000016 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Size         | 0100000000000002
@@ -26,6 +27,7 @@
 + | 0000000000000006 | (0002) ValueType                | UInt8                                            | 0100000000000001
 + | 0000000000000007 | (0002) ValueType                | Utf8                                             | 0100000000000001
 + | 0000000000000008 | (0002) ValueType                | Int64                                            | 0100000000000001
++ | 0000000000000009 | (0002) ValueType                | Null                                             | 0100000000000001
 + | 0000000000000014 | (0002) ValueType                | Utf8Insensitive                                  | 0100000000000002
 + | 0000000000000015 | (0002) ValueType                | UInt64                                           | 0100000000000002
 + | 0000000000000016 | (0002) ValueType                | UInt64                                           | 0100000000000002
@@ -54,6 +56,7 @@
 + | 0000000000000006 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000007 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000008 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000009 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000014 | (0006) Cardinality              | 1                                                | 0100000000000002
 + | 0000000000000015 | (0006) Cardinality              | 1                                                | 0100000000000002
 + | 0000000000000016 | (0006) Cardinality              | 1                                                | 0100000000000002
@@ -70,3 +73,4 @@
 + | 0100000000000002 | (0008) Timestamp                | DateTime : 1                                     | 0100000000000002
 + | 0100000000000003 | (0008) Timestamp                | DateTime : 2                                     | 0100000000000003
 + | 0100000000000004 | (0008) Timestamp                | DateTime : 3                                     | 0100000000000004
++ | 0000000000000001 | (0009) Unique                   |                                                  | 0100000000000001

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.RetractedValuesAreSupported_type=AVETCurrent.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.RetractedValuesAreSupported_type=AVETCurrent.verified.txt
@@ -3,6 +3,7 @@
 + | 0000000000000003 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Indexed          | 0100000000000001
 + | 0000000000000005 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/NoHistory        | 0100000000000001
 + | 0000000000000004 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Optional         | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
 + | 0000000000000001 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/UniqueId         | 0100000000000001
 + | 0000000000000002 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/ValueType        | 0100000000000001
 + | 000000000000001E | (0001) UniqueId                 | NexusMods.MnemonicDB.S...stAttributes/InKeyBlob  | 0100000000000002

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.RetractedValuesAreSupported_type=EAVTCurrent.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.RetractedValuesAreSupported_type=EAVTCurrent.verified.txt
@@ -2,6 +2,7 @@
 + | 0000000000000001 | (0002) ValueType                | Ascii                                            | 0100000000000001
 + | 0000000000000001 | (0003) Indexed                  |                                                  | 0100000000000001
 + | 0000000000000001 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000001 | (0009) Unique                   |                                                  | 0100000000000001
 + | 0000000000000002 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/ValueType        | 0100000000000001
 + | 0000000000000002 | (0002) ValueType                | UInt8                                            | 0100000000000001
 + | 0000000000000002 | (0006) Cardinality              | 1                                                | 0100000000000001
@@ -24,6 +25,9 @@
 + | 0000000000000008 | (0001) UniqueId                 | NexusMods.MnemonicDB.Transaction/Timestamp       | 0100000000000001
 + | 0000000000000008 | (0002) ValueType                | Int64                                            | 0100000000000001
 + | 0000000000000008 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
++ | 0000000000000009 | (0002) ValueType                | Null                                             | 0100000000000001
++ | 0000000000000009 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000014 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Path         | 0100000000000002
 + | 0000000000000014 | (0002) ValueType                | Utf8Insensitive                                  | 0100000000000002
 + | 0000000000000014 | (0003) Indexed                  |                                                  | 0100000000000002

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.RetractedValuesAreSupported_type=TxLog.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/InMemoryTests.RetractedValuesAreSupported_type=TxLog.verified.txt
@@ -2,6 +2,7 @@
 + | 0000000000000001 | (0002) ValueType                | Ascii                                            | 0100000000000001
 + | 0000000000000001 | (0003) Indexed                  |                                                  | 0100000000000001
 + | 0000000000000001 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000001 | (0009) Unique                   |                                                  | 0100000000000001
 + | 0000000000000002 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/ValueType        | 0100000000000001
 + | 0000000000000002 | (0002) ValueType                | UInt8                                            | 0100000000000001
 + | 0000000000000002 | (0006) Cardinality              | 1                                                | 0100000000000001
@@ -24,6 +25,9 @@
 + | 0000000000000008 | (0001) UniqueId                 | NexusMods.MnemonicDB.Transaction/Timestamp       | 0100000000000001
 + | 0000000000000008 | (0002) ValueType                | Int64                                            | 0100000000000001
 + | 0000000000000008 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
++ | 0000000000000009 | (0002) ValueType                | Null                                             | 0100000000000001
++ | 0000000000000009 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0100000000000001 | (0008) Timestamp                | DateTime : 0                                     | 0100000000000001
 + | 0000000000000014 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Path         | 0100000000000002
 + | 0000000000000014 | (0002) ValueType                | Utf8Insensitive                                  | 0100000000000002

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.CanStoreDataInBlobs_type=AEVTCurrent.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.CanStoreDataInBlobs_type=AEVTCurrent.verified.txt
@@ -6,6 +6,7 @@
 + | 0000000000000006 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Cardinality      | 0100000000000001
 + | 0000000000000007 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Documentation    | 0100000000000001
 + | 0000000000000008 | (0001) UniqueId                 | NexusMods.MnemonicDB.Transaction/Timestamp       | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
 + | 0000000000000014 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Path         | 0100000000000002
 + | 0000000000000015 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Hash         | 0100000000000002
 + | 0000000000000016 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Size         | 0100000000000002
@@ -26,6 +27,7 @@
 + | 0000000000000006 | (0002) ValueType                | UInt8                                            | 0100000000000001
 + | 0000000000000007 | (0002) ValueType                | Utf8                                             | 0100000000000001
 + | 0000000000000008 | (0002) ValueType                | Int64                                            | 0100000000000001
++ | 0000000000000009 | (0002) ValueType                | Null                                             | 0100000000000001
 + | 0000000000000014 | (0002) ValueType                | Utf8Insensitive                                  | 0100000000000002
 + | 0000000000000015 | (0002) ValueType                | UInt64                                           | 0100000000000002
 + | 0000000000000016 | (0002) ValueType                | UInt64                                           | 0100000000000002
@@ -54,6 +56,7 @@
 + | 0000000000000006 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000007 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000008 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000009 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000014 | (0006) Cardinality              | 1                                                | 0100000000000002
 + | 0000000000000015 | (0006) Cardinality              | 1                                                | 0100000000000002
 + | 0000000000000016 | (0006) Cardinality              | 1                                                | 0100000000000002
@@ -74,6 +77,7 @@
 + | 0100000000000006 | (0008) Timestamp                | DateTime : 5                                     | 0100000000000006
 + | 0100000000000007 | (0008) Timestamp                | DateTime : 6                                     | 0100000000000007
 + | 0100000000000008 | (0008) Timestamp                | DateTime : 7                                     | 0100000000000008
++ | 0000000000000001 | (0009) Unique                   |                                                  | 0100000000000001
 + | 0200000000000003 | (001E) InKeyBlob                | Blob 0xB85FD37A0A050E63 255 bytes                | 0100000000000005
 + | 0200000000000004 | (001E) InKeyBlob                | Blob 0xB85FD37A0A050E63 255 bytes                | 0100000000000006
 + | 0200000000000003 | (001F) InValueBlob              | HashedBlob 0x8FFA0F9DFCB11153 16777216 bytes     | 0100000000000005

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.CanStoreDataInBlobs_type=AVETCurrent.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.CanStoreDataInBlobs_type=AVETCurrent.verified.txt
@@ -3,6 +3,7 @@
 + | 0000000000000003 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Indexed          | 0100000000000001
 + | 0000000000000005 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/NoHistory        | 0100000000000001
 + | 0000000000000004 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Optional         | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
 + | 0000000000000001 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/UniqueId         | 0100000000000001
 + | 0000000000000002 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/ValueType        | 0100000000000001
 + | 000000000000001E | (0001) UniqueId                 | NexusMods.MnemonicDB.S...stAttributes/InKeyBlob  | 0100000000000002

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.CanStoreDataInBlobs_type=EAVTCurrent.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.CanStoreDataInBlobs_type=EAVTCurrent.verified.txt
@@ -2,6 +2,7 @@
 + | 0000000000000001 | (0002) ValueType                | Ascii                                            | 0100000000000001
 + | 0000000000000001 | (0003) Indexed                  |                                                  | 0100000000000001
 + | 0000000000000001 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000001 | (0009) Unique                   |                                                  | 0100000000000001
 + | 0000000000000002 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/ValueType        | 0100000000000001
 + | 0000000000000002 | (0002) ValueType                | UInt8                                            | 0100000000000001
 + | 0000000000000002 | (0006) Cardinality              | 1                                                | 0100000000000001
@@ -24,6 +25,9 @@
 + | 0000000000000008 | (0001) UniqueId                 | NexusMods.MnemonicDB.Transaction/Timestamp       | 0100000000000001
 + | 0000000000000008 | (0002) ValueType                | Int64                                            | 0100000000000001
 + | 0000000000000008 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
++ | 0000000000000009 | (0002) ValueType                | Null                                             | 0100000000000001
++ | 0000000000000009 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000014 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Path         | 0100000000000002
 + | 0000000000000014 | (0002) ValueType                | Utf8Insensitive                                  | 0100000000000002
 + | 0000000000000014 | (0003) Indexed                  |                                                  | 0100000000000002

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.CanStoreDataInBlobs_type=TxLog.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.CanStoreDataInBlobs_type=TxLog.verified.txt
@@ -2,6 +2,7 @@
 + | 0000000000000001 | (0002) ValueType                | Ascii                                            | 0100000000000001
 + | 0000000000000001 | (0003) Indexed                  |                                                  | 0100000000000001
 + | 0000000000000001 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000001 | (0009) Unique                   |                                                  | 0100000000000001
 + | 0000000000000002 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/ValueType        | 0100000000000001
 + | 0000000000000002 | (0002) ValueType                | UInt8                                            | 0100000000000001
 + | 0000000000000002 | (0006) Cardinality              | 1                                                | 0100000000000001
@@ -24,6 +25,9 @@
 + | 0000000000000008 | (0001) UniqueId                 | NexusMods.MnemonicDB.Transaction/Timestamp       | 0100000000000001
 + | 0000000000000008 | (0002) ValueType                | Int64                                            | 0100000000000001
 + | 0000000000000008 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
++ | 0000000000000009 | (0002) ValueType                | Null                                             | 0100000000000001
++ | 0000000000000009 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0100000000000001 | (0008) Timestamp                | DateTime : 0                                     | 0100000000000001
 + | 0000000000000014 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Path         | 0100000000000002
 + | 0000000000000014 | (0002) ValueType                | Utf8Insensitive                                  | 0100000000000002

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.HistoricalQueriesReturnAllDataSorted_type=AEVTCurrent.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.HistoricalQueriesReturnAllDataSorted_type=AEVTCurrent.verified.txt
@@ -6,6 +6,7 @@
 + | 0000000000000006 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Cardinality      | 0100000000000001
 + | 0000000000000007 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Documentation    | 0100000000000001
 + | 0000000000000008 | (0001) UniqueId                 | NexusMods.MnemonicDB.Transaction/Timestamp       | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
 + | 0000000000000014 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Path         | 0100000000000002
 + | 0000000000000015 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Hash         | 0100000000000002
 + | 0000000000000016 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Size         | 0100000000000002
@@ -26,6 +27,7 @@
 + | 0000000000000006 | (0002) ValueType                | UInt8                                            | 0100000000000001
 + | 0000000000000007 | (0002) ValueType                | Utf8                                             | 0100000000000001
 + | 0000000000000008 | (0002) ValueType                | Int64                                            | 0100000000000001
++ | 0000000000000009 | (0002) ValueType                | Null                                             | 0100000000000001
 + | 0000000000000014 | (0002) ValueType                | Utf8Insensitive                                  | 0100000000000002
 + | 0000000000000015 | (0002) ValueType                | UInt64                                           | 0100000000000002
 + | 0000000000000016 | (0002) ValueType                | UInt64                                           | 0100000000000002
@@ -54,6 +56,7 @@
 + | 0000000000000006 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000007 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000008 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000009 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000014 | (0006) Cardinality              | 1                                                | 0100000000000002
 + | 0000000000000015 | (0006) Cardinality              | 1                                                | 0100000000000002
 + | 0000000000000016 | (0006) Cardinality              | 1                                                | 0100000000000002
@@ -70,6 +73,7 @@
 + | 0100000000000002 | (0008) Timestamp                | DateTime : 1                                     | 0100000000000002
 + | 0100000000000003 | (0008) Timestamp                | DateTime : 2                                     | 0100000000000003
 + | 0100000000000004 | (0008) Timestamp                | DateTime : 3                                     | 0100000000000004
++ | 0000000000000001 | (0009) Unique                   |                                                  | 0100000000000001
 + | 0200000000000001 | (0014) Path                     | /foo/bar                                         | 0100000000000003
 + | 0200000000000002 | (0014) Path                     | /foo/qux                                         | 0100000000000004
 + | 0200000000000002 | (0014) Path                     | /qix/bar                                         | 0100000000000003

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.HistoricalQueriesReturnAllDataSorted_type=AEVTHistory.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.HistoricalQueriesReturnAllDataSorted_type=AEVTHistory.verified.txt
@@ -6,6 +6,7 @@
 + | 0000000000000006 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Cardinality      | 0100000000000001
 + | 0000000000000007 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Documentation    | 0100000000000001
 + | 0000000000000008 | (0001) UniqueId                 | NexusMods.MnemonicDB.Transaction/Timestamp       | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
 + | 0000000000000014 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Path         | 0100000000000002
 + | 0000000000000015 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Hash         | 0100000000000002
 + | 0000000000000016 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Size         | 0100000000000002
@@ -26,6 +27,7 @@
 + | 0000000000000006 | (0002) ValueType                | UInt8                                            | 0100000000000001
 + | 0000000000000007 | (0002) ValueType                | Utf8                                             | 0100000000000001
 + | 0000000000000008 | (0002) ValueType                | Int64                                            | 0100000000000001
++ | 0000000000000009 | (0002) ValueType                | Null                                             | 0100000000000001
 + | 0000000000000014 | (0002) ValueType                | Utf8Insensitive                                  | 0100000000000002
 + | 0000000000000015 | (0002) ValueType                | UInt64                                           | 0100000000000002
 + | 0000000000000016 | (0002) ValueType                | UInt64                                           | 0100000000000002
@@ -54,6 +56,7 @@
 + | 0000000000000006 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000007 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000008 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000009 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000014 | (0006) Cardinality              | 1                                                | 0100000000000002
 + | 0000000000000015 | (0006) Cardinality              | 1                                                | 0100000000000002
 + | 0000000000000016 | (0006) Cardinality              | 1                                                | 0100000000000002
@@ -70,6 +73,7 @@
 + | 0100000000000002 | (0008) Timestamp                | DateTime : 1                                     | 0100000000000002
 + | 0100000000000003 | (0008) Timestamp                | DateTime : 2                                     | 0100000000000003
 + | 0100000000000004 | (0008) Timestamp                | DateTime : 3                                     | 0100000000000004
++ | 0000000000000001 | (0009) Unique                   |                                                  | 0100000000000001
 + | 0200000000000001 | (0014) Path                     | /foo/bar                                         | 0100000000000003
 + | 0200000000000002 | (0014) Path                     | /foo/qux                                         | 0100000000000004
 + | 0200000000000002 | (0014) Path                     | /qix/bar                                         | 0100000000000003

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.HistoricalQueriesReturnAllDataSorted_type=AVETCurrent.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.HistoricalQueriesReturnAllDataSorted_type=AVETCurrent.verified.txt
@@ -3,6 +3,7 @@
 + | 0000000000000003 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Indexed          | 0100000000000001
 + | 0000000000000005 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/NoHistory        | 0100000000000001
 + | 0000000000000004 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Optional         | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
 + | 0000000000000001 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/UniqueId         | 0100000000000001
 + | 0000000000000002 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/ValueType        | 0100000000000001
 + | 000000000000001E | (0001) UniqueId                 | NexusMods.MnemonicDB.S...stAttributes/InKeyBlob  | 0100000000000002

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.HistoricalQueriesReturnAllDataSorted_type=AVETHistory.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.HistoricalQueriesReturnAllDataSorted_type=AVETHistory.verified.txt
@@ -3,6 +3,7 @@
 + | 0000000000000003 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Indexed          | 0100000000000001
 + | 0000000000000005 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/NoHistory        | 0100000000000001
 + | 0000000000000004 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Optional         | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
 + | 0000000000000001 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/UniqueId         | 0100000000000001
 + | 0000000000000002 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/ValueType        | 0100000000000001
 + | 000000000000001E | (0001) UniqueId                 | NexusMods.MnemonicDB.S...stAttributes/InKeyBlob  | 0100000000000002

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.HistoricalQueriesReturnAllDataSorted_type=EAVTCurrent.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.HistoricalQueriesReturnAllDataSorted_type=EAVTCurrent.verified.txt
@@ -2,6 +2,7 @@
 + | 0000000000000001 | (0002) ValueType                | Ascii                                            | 0100000000000001
 + | 0000000000000001 | (0003) Indexed                  |                                                  | 0100000000000001
 + | 0000000000000001 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000001 | (0009) Unique                   |                                                  | 0100000000000001
 + | 0000000000000002 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/ValueType        | 0100000000000001
 + | 0000000000000002 | (0002) ValueType                | UInt8                                            | 0100000000000001
 + | 0000000000000002 | (0006) Cardinality              | 1                                                | 0100000000000001
@@ -24,6 +25,9 @@
 + | 0000000000000008 | (0001) UniqueId                 | NexusMods.MnemonicDB.Transaction/Timestamp       | 0100000000000001
 + | 0000000000000008 | (0002) ValueType                | Int64                                            | 0100000000000001
 + | 0000000000000008 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
++ | 0000000000000009 | (0002) ValueType                | Null                                             | 0100000000000001
++ | 0000000000000009 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000014 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Path         | 0100000000000002
 + | 0000000000000014 | (0002) ValueType                | Utf8Insensitive                                  | 0100000000000002
 + | 0000000000000014 | (0003) Indexed                  |                                                  | 0100000000000002

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.HistoricalQueriesReturnAllDataSorted_type=EAVTHistory.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.HistoricalQueriesReturnAllDataSorted_type=EAVTHistory.verified.txt
@@ -2,6 +2,7 @@
 + | 0000000000000001 | (0002) ValueType                | Ascii                                            | 0100000000000001
 + | 0000000000000001 | (0003) Indexed                  |                                                  | 0100000000000001
 + | 0000000000000001 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000001 | (0009) Unique                   |                                                  | 0100000000000001
 + | 0000000000000002 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/ValueType        | 0100000000000001
 + | 0000000000000002 | (0002) ValueType                | UInt8                                            | 0100000000000001
 + | 0000000000000002 | (0006) Cardinality              | 1                                                | 0100000000000001
@@ -24,6 +25,9 @@
 + | 0000000000000008 | (0001) UniqueId                 | NexusMods.MnemonicDB.Transaction/Timestamp       | 0100000000000001
 + | 0000000000000008 | (0002) ValueType                | Int64                                            | 0100000000000001
 + | 0000000000000008 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
++ | 0000000000000009 | (0002) ValueType                | Null                                             | 0100000000000001
++ | 0000000000000009 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000014 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Path         | 0100000000000002
 + | 0000000000000014 | (0002) ValueType                | Utf8Insensitive                                  | 0100000000000002
 + | 0000000000000014 | (0003) Indexed                  |                                                  | 0100000000000002

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.InsertedDatomsShowUpInTheIndex_type=AEVTCurrent.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.InsertedDatomsShowUpInTheIndex_type=AEVTCurrent.verified.txt
@@ -6,6 +6,7 @@
 + | 0000000000000006 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Cardinality      | 0100000000000001
 + | 0000000000000007 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Documentation    | 0100000000000001
 + | 0000000000000008 | (0001) UniqueId                 | NexusMods.MnemonicDB.Transaction/Timestamp       | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
 + | 0000000000000014 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Path         | 0100000000000002
 + | 0000000000000015 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Hash         | 0100000000000002
 + | 0000000000000016 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Size         | 0100000000000002
@@ -26,6 +27,7 @@
 + | 0000000000000006 | (0002) ValueType                | UInt8                                            | 0100000000000001
 + | 0000000000000007 | (0002) ValueType                | Utf8                                             | 0100000000000001
 + | 0000000000000008 | (0002) ValueType                | Int64                                            | 0100000000000001
++ | 0000000000000009 | (0002) ValueType                | Null                                             | 0100000000000001
 + | 0000000000000014 | (0002) ValueType                | Utf8Insensitive                                  | 0100000000000002
 + | 0000000000000015 | (0002) ValueType                | UInt64                                           | 0100000000000002
 + | 0000000000000016 | (0002) ValueType                | UInt64                                           | 0100000000000002
@@ -54,6 +56,7 @@
 + | 0000000000000006 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000007 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000008 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000009 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000014 | (0006) Cardinality              | 1                                                | 0100000000000002
 + | 0000000000000015 | (0006) Cardinality              | 1                                                | 0100000000000002
 + | 0000000000000016 | (0006) Cardinality              | 1                                                | 0100000000000002
@@ -70,6 +73,7 @@
 + | 0100000000000002 | (0008) Timestamp                | DateTime : 1                                     | 0100000000000002
 + | 0100000000000003 | (0008) Timestamp                | DateTime : 2                                     | 0100000000000003
 + | 0100000000000004 | (0008) Timestamp                | DateTime : 3                                     | 0100000000000004
++ | 0000000000000001 | (0009) Unique                   |                                                  | 0100000000000001
 + | 0200000000000001 | (0014) Path                     | /foo/bar                                         | 0100000000000003
 + | 0200000000000002 | (0014) Path                     | /foo/qux                                         | 0100000000000004
 + | 0200000000000001 | (0015) Hash                     | 0x00000000DEADBEEF                               | 0100000000000003

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.InsertedDatomsShowUpInTheIndex_type=AVETCurrent.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.InsertedDatomsShowUpInTheIndex_type=AVETCurrent.verified.txt
@@ -3,6 +3,7 @@
 + | 0000000000000003 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Indexed          | 0100000000000001
 + | 0000000000000005 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/NoHistory        | 0100000000000001
 + | 0000000000000004 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Optional         | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
 + | 0000000000000001 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/UniqueId         | 0100000000000001
 + | 0000000000000002 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/ValueType        | 0100000000000001
 + | 000000000000001E | (0001) UniqueId                 | NexusMods.MnemonicDB.S...stAttributes/InKeyBlob  | 0100000000000002

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.InsertedDatomsShowUpInTheIndex_type=EAVTCurrent.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.InsertedDatomsShowUpInTheIndex_type=EAVTCurrent.verified.txt
@@ -2,6 +2,7 @@
 + | 0000000000000001 | (0002) ValueType                | Ascii                                            | 0100000000000001
 + | 0000000000000001 | (0003) Indexed                  |                                                  | 0100000000000001
 + | 0000000000000001 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000001 | (0009) Unique                   |                                                  | 0100000000000001
 + | 0000000000000002 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/ValueType        | 0100000000000001
 + | 0000000000000002 | (0002) ValueType                | UInt8                                            | 0100000000000001
 + | 0000000000000002 | (0006) Cardinality              | 1                                                | 0100000000000001
@@ -24,6 +25,9 @@
 + | 0000000000000008 | (0001) UniqueId                 | NexusMods.MnemonicDB.Transaction/Timestamp       | 0100000000000001
 + | 0000000000000008 | (0002) ValueType                | Int64                                            | 0100000000000001
 + | 0000000000000008 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
++ | 0000000000000009 | (0002) ValueType                | Null                                             | 0100000000000001
++ | 0000000000000009 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000014 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Path         | 0100000000000002
 + | 0000000000000014 | (0002) ValueType                | Utf8Insensitive                                  | 0100000000000002
 + | 0000000000000014 | (0003) Indexed                  |                                                  | 0100000000000002

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.InsertedDatomsShowUpInTheIndex_type=TxLog.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.InsertedDatomsShowUpInTheIndex_type=TxLog.verified.txt
@@ -2,6 +2,7 @@
 + | 0000000000000001 | (0002) ValueType                | Ascii                                            | 0100000000000001
 + | 0000000000000001 | (0003) Indexed                  |                                                  | 0100000000000001
 + | 0000000000000001 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000001 | (0009) Unique                   |                                                  | 0100000000000001
 + | 0000000000000002 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/ValueType        | 0100000000000001
 + | 0000000000000002 | (0002) ValueType                | UInt8                                            | 0100000000000001
 + | 0000000000000002 | (0006) Cardinality              | 1                                                | 0100000000000001
@@ -24,6 +25,9 @@
 + | 0000000000000008 | (0001) UniqueId                 | NexusMods.MnemonicDB.Transaction/Timestamp       | 0100000000000001
 + | 0000000000000008 | (0002) ValueType                | Int64                                            | 0100000000000001
 + | 0000000000000008 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
++ | 0000000000000009 | (0002) ValueType                | Null                                             | 0100000000000001
++ | 0000000000000009 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0100000000000001 | (0008) Timestamp                | DateTime : 0                                     | 0100000000000001
 + | 0000000000000014 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Path         | 0100000000000002
 + | 0000000000000014 | (0002) ValueType                | Utf8Insensitive                                  | 0100000000000002

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.RetractedValuesAreSupported_type=AEVTCurrent.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.RetractedValuesAreSupported_type=AEVTCurrent.verified.txt
@@ -6,6 +6,7 @@
 + | 0000000000000006 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Cardinality      | 0100000000000001
 + | 0000000000000007 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Documentation    | 0100000000000001
 + | 0000000000000008 | (0001) UniqueId                 | NexusMods.MnemonicDB.Transaction/Timestamp       | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
 + | 0000000000000014 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Path         | 0100000000000002
 + | 0000000000000015 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Hash         | 0100000000000002
 + | 0000000000000016 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Size         | 0100000000000002
@@ -26,6 +27,7 @@
 + | 0000000000000006 | (0002) ValueType                | UInt8                                            | 0100000000000001
 + | 0000000000000007 | (0002) ValueType                | Utf8                                             | 0100000000000001
 + | 0000000000000008 | (0002) ValueType                | Int64                                            | 0100000000000001
++ | 0000000000000009 | (0002) ValueType                | Null                                             | 0100000000000001
 + | 0000000000000014 | (0002) ValueType                | Utf8Insensitive                                  | 0100000000000002
 + | 0000000000000015 | (0002) ValueType                | UInt64                                           | 0100000000000002
 + | 0000000000000016 | (0002) ValueType                | UInt64                                           | 0100000000000002
@@ -54,6 +56,7 @@
 + | 0000000000000006 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000007 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000008 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000009 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000014 | (0006) Cardinality              | 1                                                | 0100000000000002
 + | 0000000000000015 | (0006) Cardinality              | 1                                                | 0100000000000002
 + | 0000000000000016 | (0006) Cardinality              | 1                                                | 0100000000000002
@@ -70,3 +73,4 @@
 + | 0100000000000002 | (0008) Timestamp                | DateTime : 1                                     | 0100000000000002
 + | 0100000000000003 | (0008) Timestamp                | DateTime : 2                                     | 0100000000000003
 + | 0100000000000004 | (0008) Timestamp                | DateTime : 3                                     | 0100000000000004
++ | 0000000000000001 | (0009) Unique                   |                                                  | 0100000000000001

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.RetractedValuesAreSupported_type=AVETCurrent.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.RetractedValuesAreSupported_type=AVETCurrent.verified.txt
@@ -3,6 +3,7 @@
 + | 0000000000000003 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Indexed          | 0100000000000001
 + | 0000000000000005 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/NoHistory        | 0100000000000001
 + | 0000000000000004 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Optional         | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
 + | 0000000000000001 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/UniqueId         | 0100000000000001
 + | 0000000000000002 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/ValueType        | 0100000000000001
 + | 000000000000001E | (0001) UniqueId                 | NexusMods.MnemonicDB.S...stAttributes/InKeyBlob  | 0100000000000002

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.RetractedValuesAreSupported_type=EAVTCurrent.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.RetractedValuesAreSupported_type=EAVTCurrent.verified.txt
@@ -2,6 +2,7 @@
 + | 0000000000000001 | (0002) ValueType                | Ascii                                            | 0100000000000001
 + | 0000000000000001 | (0003) Indexed                  |                                                  | 0100000000000001
 + | 0000000000000001 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000001 | (0009) Unique                   |                                                  | 0100000000000001
 + | 0000000000000002 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/ValueType        | 0100000000000001
 + | 0000000000000002 | (0002) ValueType                | UInt8                                            | 0100000000000001
 + | 0000000000000002 | (0006) Cardinality              | 1                                                | 0100000000000001
@@ -24,6 +25,9 @@
 + | 0000000000000008 | (0001) UniqueId                 | NexusMods.MnemonicDB.Transaction/Timestamp       | 0100000000000001
 + | 0000000000000008 | (0002) ValueType                | Int64                                            | 0100000000000001
 + | 0000000000000008 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
++ | 0000000000000009 | (0002) ValueType                | Null                                             | 0100000000000001
++ | 0000000000000009 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0000000000000014 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Path         | 0100000000000002
 + | 0000000000000014 | (0002) ValueType                | Utf8Insensitive                                  | 0100000000000002
 + | 0000000000000014 | (0003) Indexed                  |                                                  | 0100000000000002

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.RetractedValuesAreSupported_type=TxLog.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/BackendTestVerifyData/RocksDB.RetractedValuesAreSupported_type=TxLog.verified.txt
@@ -2,6 +2,7 @@
 + | 0000000000000001 | (0002) ValueType                | Ascii                                            | 0100000000000001
 + | 0000000000000001 | (0003) Indexed                  |                                                  | 0100000000000001
 + | 0000000000000001 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000001 | (0009) Unique                   |                                                  | 0100000000000001
 + | 0000000000000002 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/ValueType        | 0100000000000001
 + | 0000000000000002 | (0002) ValueType                | UInt8                                            | 0100000000000001
 + | 0000000000000002 | (0006) Cardinality              | 1                                                | 0100000000000001
@@ -24,6 +25,9 @@
 + | 0000000000000008 | (0001) UniqueId                 | NexusMods.MnemonicDB.Transaction/Timestamp       | 0100000000000001
 + | 0000000000000008 | (0002) ValueType                | Int64                                            | 0100000000000001
 + | 0000000000000008 | (0006) Cardinality              | 1                                                | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
++ | 0000000000000009 | (0002) ValueType                | Null                                             | 0100000000000001
++ | 0000000000000009 | (0006) Cardinality              | 1                                                | 0100000000000001
 + | 0100000000000001 | (0008) Timestamp                | DateTime : 0                                     | 0100000000000001
 + | 0000000000000014 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Path         | 0100000000000002
 + | 0000000000000014 | (0002) ValueType                | Utf8Insensitive                                  | 0100000000000002

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/InMemoryTests.CanLoadExistingAttributes.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/InMemoryTests.CanLoadExistingAttributes.verified.txt
@@ -6,6 +6,7 @@
 + | 0000000000000006 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Cardinality      | 0100000000000001
 + | 0000000000000007 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Documentation    | 0100000000000001
 + | 0000000000000008 | (0001) UniqueId                 | NexusMods.MnemonicDB.Transaction/Timestamp       | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
 + | 0000000000000014 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Path         | 0100000000000002
 + | 0000000000000015 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Hash         | 0100000000000002
 + | 0000000000000016 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Size         | 0100000000000002

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/RocksDB.CanLoadExistingAttributes.verified.txt
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/RocksDB.CanLoadExistingAttributes.verified.txt
@@ -6,6 +6,7 @@
 + | 0000000000000006 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Cardinality      | 0100000000000001
 + | 0000000000000007 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Documentation    | 0100000000000001
 + | 0000000000000008 | (0001) UniqueId                 | NexusMods.MnemonicDB.Transaction/Timestamp       | 0100000000000001
++ | 0000000000000009 | (0001) UniqueId                 | NexusMods.MnemonicDB.DatomStore/Unique           | 0100000000000001
 + | 0000000000000014 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Path         | 0100000000000002
 + | 0000000000000015 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Hash         | 0100000000000002
 + | 0000000000000016 | (0001) UniqueId                 | NexusMods.MnemonicDB.TestModel.File/Size         | 0100000000000002

--- a/tests/NexusMods.MnemonicDB.TestModel/ArchiveFile.cs
+++ b/tests/NexusMods.MnemonicDB.TestModel/ArchiveFile.cs
@@ -20,5 +20,5 @@ public partial class ArchiveFile : IModelDefinition
     /// <summary>
     /// The hash of the file in the archive
     /// </summary>
-    public static readonly HashAttribute Hash = new(Namespace, nameof(Hash)) { IsUnique = true };
+    public static readonly HashAttribute Hash = new(Namespace, nameof(Hash)) { IsUnique = true, IsIndexed = true };
 }

--- a/tests/NexusMods.MnemonicDB.TestModel/ArchiveFile.cs
+++ b/tests/NexusMods.MnemonicDB.TestModel/ArchiveFile.cs
@@ -16,9 +16,9 @@ public partial class ArchiveFile : IModelDefinition
     /// The path of the file in the archive
     /// </summary>
     public static readonly RelativePathAttribute Path = new(Namespace, nameof(Path)) { IsIndexed = true };
-    
+
     /// <summary>
     /// The hash of the file in the archive
     /// </summary>
-    public static readonly HashAttribute Hash = new(Namespace, nameof(Hash));
+    public static readonly HashAttribute Hash = new(Namespace, nameof(Hash)) { IsUnique = true };
 }


### PR DESCRIPTION
Adds a `Unique` field to attributes. If true, then a given attribute/value pair can only have a single associated entity at a time. The code here is a little more complex than one would initially think, because it has to support the retraction/addition of a unique value inside the same transaction so that these unique ids can have atomic updates (transfer the unique value from one entity to the other). Since MnemonicDB transactions processess their datoms in a undefined order, we have to handle cases where the retract comes after the assert.