### PR TITLE
Add support for (almost) lock free observers. 

### DIFF
--- a/src/NexusMods.MnemonicDB.Abstractions/Query/SliceDescriptor.cs
+++ b/src/NexusMods.MnemonicDB.Abstractions/Query/SliceDescriptor.cs
@@ -170,6 +170,18 @@ public readonly struct SliceDescriptor
     }
 
     /// <summary>
+    /// Creates a slice descriptor for the given datoms
+    /// </summary>
+    public static SliceDescriptor Create(Datom from, Datom to)
+    {
+        return new SliceDescriptor()
+        {
+            From = from,
+            To = to
+        };
+    }
+
+    /// <summary>
     /// Creates a slice descriptor for the given attribute from the current AEVT index
     /// reverse lookup.
     /// </summary>

--- a/src/NexusMods.MnemonicDB/Box.cs
+++ b/src/NexusMods.MnemonicDB/Box.cs
@@ -1,0 +1,14 @@
+namespace NexusMods.MnemonicDB;
+
+/// <summary>
+/// A object wrapper for a value, useful for mutating values between calls to a closure
+/// </summary>
+public sealed class Box<T>
+{
+    public Box(T value)
+    {
+        Value = value;
+    }
+
+    public T Value { get; set; }
+}


### PR DESCRIPTION
We took the more complex route here, lock as little as possible, but then look at the updates we get for each observer and either drop duplicated events, or catchup with missed events. 