### PR TITLE
Create ReadOptions once per snapshot

### DIFF
--- a/src/NexusMods.MnemonicDB/Storage/RocksDbBackend/Backend.cs
+++ b/src/NexusMods.MnemonicDB/Storage/RocksDbBackend/Backend.cs
@@ -37,7 +37,9 @@ public class Backend : IStoreBackend
     /// <inheritdoc />
     public ISnapshot GetSnapshot()
     {
-        return new Snapshot(this, AttributeCache);
+        var snapShot = Db!.CreateSnapshot();
+        var readOptions = new ReadOptions().SetSnapshot(snapShot);
+        return new Snapshot(this, AttributeCache, readOptions, snapShot);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
Previously: 

Every call to `.Datoms` create a RocksDB ReadOptions object. This object would later be cleaned up by the finalizer. 

Now:

New snapshots (one per transaction) auto-create their ReadOptions once, and those options are reused for the life of the snapshot. 