### PR TITLE
Better Shutdowns

### DIFF
--- a/src/NexusMods.MnemonicDB/Storage/DatomStore.cs
+++ b/src/NexusMods.MnemonicDB/Storage/DatomStore.cs
@@ -207,7 +207,6 @@ public sealed partial class DatomStore : IDatomStore
 
         _pendingTransactions.CompleteAdding();
         _shutdownToken.Cancel();
-        _loggerThread?.Join();
         _dbStream.Dispose();
         _writer.Dispose();
         _retractWriter.Dispose();


### PR DESCRIPTION

* Make sure we properly exit from the Connection event thread
* Don't call `.Join()` on background threads as this could potentially cause a deadlock during shutdown. 