### PR TITLE
Add sub-transactions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,6 +1,6 @@
 <Project>
   <ItemGroup>
-    <PackageVersion Include="DynamicData" Version="9.2.2" />
+    <PackageVersion Include="DynamicData" Version="9.3.2" />
     <PackageVersion Include="Halgari.Jamarino.IntervalTree" Version="1.0.0-alpha" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />

--- a/NexusMods.MnemonicDB.sln
+++ b/NexusMods.MnemonicDB.sln
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".solutionItems", ".solution
 		Directory.Build.targets = Directory.Build.targets
 		NuGet.Build.props = NuGet.Build.props
 		icon.png = icon.png
+		Directory.Packages.props = Directory.Packages.props
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{0377EBE6-F147-4233-86AD-32C821B9567E}"

--- a/src/NexusMods.MnemonicDB.Abstractions/IConnection.cs
+++ b/src/NexusMods.MnemonicDB.Abstractions/IConnection.cs
@@ -74,8 +74,8 @@ public interface IConnection : IDisposable
     ///     Starts a new transaction.
     /// </summary>
     /// <returns></returns>
-    public ITransaction BeginTransaction();
-    
+    public IMainTransaction BeginTransaction();
+
     /// <summary>
     /// The analyzers that are available for this connection
     /// </summary>

--- a/src/NexusMods.MnemonicDB.Abstractions/ITransaction.cs
+++ b/src/NexusMods.MnemonicDB.Abstractions/ITransaction.cs
@@ -88,7 +88,23 @@ public interface ITransaction : IDisposable
         where TEntity : class, ITemporaryEntity;
 
     /// <summary>
+    /// Creates a sub-transaction.
+    /// </summary>
+    [MustDisposeResource] ISubTransaction CreateSubTransaction();
+
+    /// <summary>
     ///     Commits the transaction
     /// </summary>
     Task<ICommitResult> Commit();
+
+    /// <summary>
+    /// Resets the transaction.
+    /// </summary>
+    void Reset();
 }
+
+/// <summary>
+/// A sub-transaction.
+/// </summary>
+[PublicAPI]
+public interface ISubTransaction : ITransaction;

--- a/src/NexusMods.MnemonicDB.Abstractions/ITransaction.cs
+++ b/src/NexusMods.MnemonicDB.Abstractions/ITransaction.cs
@@ -90,12 +90,7 @@ public interface ITransaction : IDisposable
     /// <summary>
     /// Creates a sub-transaction.
     /// </summary>
-    [MustDisposeResource] ISubTransaction CreateSubTransaction();
-
-    /// <summary>
-    ///     Commits the transaction
-    /// </summary>
-    Task<ICommitResult> Commit();
+    ISubTransaction CreateSubTransaction();
 
     /// <summary>
     /// Resets the transaction.
@@ -104,7 +99,25 @@ public interface ITransaction : IDisposable
 }
 
 /// <summary>
+/// Represents a transaction that can be committed to the DB.
+/// </summary>
+[PublicAPI]
+public interface IMainTransaction : ITransaction
+{
+    /// <summary>
+    /// Commits the transaction
+    /// </summary>
+    Task<ICommitResult> Commit();
+}
+
+/// <summary>
 /// A sub-transaction.
 /// </summary>
 [PublicAPI]
-public interface ISubTransaction : ITransaction;
+public interface ISubTransaction : ITransaction
+{
+    /// <summary>
+    /// Commits the data to the parent transaction.
+    /// </summary>
+    void CommitToParent();
+}

--- a/src/NexusMods.MnemonicDB/Connection.cs
+++ b/src/NexusMods.MnemonicDB/Connection.cs
@@ -361,9 +361,9 @@ public sealed class Connection : IConnection
     }
 
     /// <inheritdoc />
-    public ITransaction BeginTransaction()
+    public IMainTransaction BeginTransaction()
     {
-        return new Transaction(this);
+        return new Transaction(connection: this);
     }
 
     /// <inheritdoc />

--- a/src/NexusMods.MnemonicDB/Storage/InternalTransaction.cs
+++ b/src/NexusMods.MnemonicDB/Storage/InternalTransaction.cs
@@ -93,7 +93,19 @@ internal class InternalTransaction(IDb basisDb, IndexSegmentBuilder datoms) : IT
     }
 
     /// <inheritdoc />
+    public ISubTransaction CreateSubTransaction()
+    {
+        throw new NotSupportedException();
+    }
+
+    /// <inheritdoc />
     public Task<ICommitResult> Commit()
+    {
+        throw new NotSupportedException();
+    }
+
+    /// <inheritdoc />
+    public void Reset()
     {
         throw new NotSupportedException();
     }
@@ -116,6 +128,4 @@ internal class InternalTransaction(IDb basisDb, IndexSegmentBuilder datoms) : IT
     public void Dispose()
     {
     }
-
-
 }

--- a/src/NexusMods.MnemonicDB/Transaction.cs
+++ b/src/NexusMods.MnemonicDB/Transaction.cs
@@ -164,6 +164,7 @@ internal sealed class Transaction : IMainTransaction, ISubTransaction
 
     public void CommitToParent()
     {
+        CheckAccess();
         Debug.Assert(_parentTransaction is not null);
 
         var indexSegment = _datoms.Build();
@@ -178,9 +179,6 @@ internal sealed class Transaction : IMainTransaction, ISubTransaction
             {
                 _parentTransaction.Attach(tmpEntity);
             }
-
-            _tempEntities.Clear();
-            _tempEntities = null;
         }
 
         if (_txFunctions is not null)
@@ -189,14 +187,14 @@ internal sealed class Transaction : IMainTransaction, ISubTransaction
             {
                 _parentTransaction.Add(txFunction);
             }
-
-            _txFunctions.Clear();
-            _txFunctions = null;
         }
+
+        _committed = true;
     }
 
     public async Task<ICommitResult> Commit()
     {
+        CheckAccess();
         Debug.Assert(_parentTransaction is null);
 
         IndexSegment built;

--- a/src/NexusMods.MnemonicDB/Transaction.cs
+++ b/src/NexusMods.MnemonicDB/Transaction.cs
@@ -3,12 +3,12 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using NexusMods.MnemonicDB.Abstractions;
 using NexusMods.MnemonicDB.Abstractions.Attributes;
 using NexusMods.MnemonicDB.Abstractions.DatomIterators;
 using NexusMods.MnemonicDB.Abstractions.ElementComparers;
 using NexusMods.MnemonicDB.Abstractions.IndexSegments;
-using NexusMods.MnemonicDB.Abstractions.Internals;
 using NexusMods.MnemonicDB.Abstractions.Models;
 using NexusMods.MnemonicDB.Abstractions.TxFunctions;
 using NexusMods.MnemonicDB.InternalTxFunctions;
@@ -16,19 +16,37 @@ using NexusMods.MnemonicDB.InternalTxFunctions;
 namespace NexusMods.MnemonicDB;
 
 /// <inheritdoc />
-internal class Transaction(Connection connection) : ITransaction
+internal class Transaction : ISubTransaction
 {
-    private readonly IndexSegmentBuilder _datoms = new(connection.AttributeCache);
-    private HashSet<ITxFunction>? _txFunctions; // No reason to create the hashset if we don't need it
+    private readonly Connection _connection;
+    private readonly IndexSegmentBuilder _datoms;
+    private readonly Lock _lock = new();
+
+    private readonly Transaction? _parentTransaction;
+
+    private HashSet<ITxFunction>? _txFunctions;
     private List<ITemporaryEntity>? _tempEntities;
-    private ulong _tempId = PartitionId.Temp.MakeEntityId(1).Value;
-    private bool _committed;
-    private readonly object _lock = new();
     private IInternalTxFunction? _internalTxFunction;
+
+    private bool _committed;
+    private ulong _tempId = PartitionId.Temp.MakeEntityId(1).Value;
+
+    public Transaction(Connection connection, Transaction? parentTransaction = null)
+    {
+        _connection = connection;
+        _datoms = new IndexSegmentBuilder(connection.AttributeCache);
+
+        _parentTransaction = parentTransaction;
+    }
+
+    /// <inheritdoc />
+    public TxId ThisTxId => _parentTransaction?.ThisTxId ?? TxId.From(PartitionId.Temp.MakeEntityId(0).Value);
 
     /// <inhertdoc />
     public EntityId TempId(PartitionId entityPartition)
     {
+        if (_parentTransaction is not null) return _parentTransaction.TempId(entityPartition);
+
         var tempId = Interlocked.Increment(ref _tempId);
         // Add the partition to the id
         var actualId = ((ulong)entityPartition << 40) | tempId;
@@ -38,6 +56,7 @@ internal class Transaction(Connection connection) : ITransaction
     /// <inhertdoc />
     public EntityId TempId()
     {
+        if (_parentTransaction is not null) return _parentTransaction.TempId();
         return TempId(PartitionId.Entity);
     }
 
@@ -46,9 +65,7 @@ internal class Transaction(Connection connection) : ITransaction
     {
         lock (_lock)
         {
-            if (_committed)
-                throw new InvalidOperationException("Transaction has already been committed");
-
+            ThrowIfCommitted();
             _datoms.Add(entityId, attribute, val, ThisTxId, isRetract);
         }
     }
@@ -57,9 +74,7 @@ internal class Transaction(Connection connection) : ITransaction
     {
         lock (_lock)
         {
-            if (_committed)
-                throw new InvalidOperationException("Transaction has already been committed");
-
+            ThrowIfCommitted();
             _datoms.Add(entityId, attribute, val, ThisTxId, isRetract);
         }
     }
@@ -68,9 +83,7 @@ internal class Transaction(Connection connection) : ITransaction
     {
         lock (_lock)
         {
-            if (_committed)
-                throw new InvalidOperationException("Transaction has already been committed");
-
+            ThrowIfCommitted();
             foreach (var id in ids)
             {
                 _datoms.Add(entityId, attribute, id, ThisTxId, isRetract: false);
@@ -82,9 +95,7 @@ internal class Transaction(Connection connection) : ITransaction
     {
         lock (_lock)
         {
-            if (_committed)
-                throw new InvalidOperationException("Transaction has already been committed");
-
+            ThrowIfCommitted();
             _datoms.Add(e, a, valueTag, valueSpan, isRetract);
         }
     }
@@ -94,6 +105,7 @@ internal class Transaction(Connection connection) : ITransaction
     {
         lock (_lock)
         {
+            ThrowIfCommitted();
             _datoms.Add(datom);
         }
     }
@@ -102,8 +114,7 @@ internal class Transaction(Connection connection) : ITransaction
     {
         lock (_lock)
         {
-            if (_committed)
-                throw new InvalidOperationException("Transaction has already been committed");
+            ThrowIfCommitted();
 
             _txFunctions ??= [];
             _txFunctions?.Add(fn);
@@ -122,6 +133,7 @@ internal class Transaction(Connection connection) : ITransaction
     {
         lock (_lock)
         {
+            ThrowIfCommitted();
             _tempEntities ??= [];
             _tempEntities.Add(entity);
         }
@@ -152,37 +164,91 @@ internal class Transaction(Connection connection) : ITransaction
 
     public async Task<ICommitResult> Commit()
     {
+        if (_parentTransaction is not null) throw new NotSupportedException("Sub-transactions can't be committed");
+
         IndexSegment built;
         lock (_lock)
         {
-            if (_tempEntities != null)
+            if (_tempEntities is not null)
             {
-                foreach (var entity in _tempEntities!)
+                foreach (var entity in _tempEntities)
                 {
                     entity.AddTo(this);
                 }
             }
 
             _committed = true;
+
             // Build the datoms block here, so that future calls to add won't modify this while we're building
             built = _datoms.Build();
         }
         
         if (_internalTxFunction is not null)
-            return await connection.Transact(_internalTxFunction);
+            return await _connection.Transact(_internalTxFunction);
 
         if (_txFunctions is not null) 
-            return await connection.Transact(new CompoundTransaction(built, _txFunctions!) { Connection = connection });
+            return await _connection.Transact(new CompoundTransaction(built, _txFunctions) { Connection = _connection });
         
-        return await connection.Transact(new IndexSegmentTransaction(built));
-
+        return await _connection.Transact(new IndexSegmentTransaction(built));
     }
 
-    /// <inheritdoc />
-    public TxId ThisTxId => TxId.From(PartitionId.Temp.MakeEntityId(0).Value);
+    [MustDisposeResource] public ISubTransaction CreateSubTransaction()
+    {
+        return new Transaction(_connection, parentTransaction: this);
+    }
+
+    public void Reset()
+    {
+        _datoms.Reset();
+
+        _tempEntities?.Clear();
+        _tempEntities = null;
+
+        _txFunctions?.Clear();
+        _txFunctions = null;
+    }
+
+    private void UpdateParent()
+    {
+        if (_parentTransaction is null) return;
+
+        var indexSegment = _datoms.Build();
+        foreach (var datom in indexSegment)
+        {
+            _parentTransaction.Add(datom);
+        }
+
+        if (_tempEntities is not null)
+        {
+            foreach (var tmpEntity in _tempEntities)
+            {
+                _parentTransaction.Attach(tmpEntity);
+            }
+
+            _tempEntities.Clear();
+            _tempEntities = null;
+        }
+
+        if (_txFunctions is not null)
+        {
+            foreach (var txFunction in _txFunctions)
+            {
+                _parentTransaction.Add(txFunction);
+            }
+
+            _txFunctions.Clear();
+            _txFunctions = null;
+        }
+    }
 
     public void Dispose()
     {
+        UpdateParent();
         _datoms.Dispose();
+    }
+
+    private void ThrowIfCommitted()
+    {
+        if (_committed) throw new InvalidOperationException("Transaction has already been committed!");
     }
 }

--- a/tests/NexusMods.MnemonicDB.Storage.Tests/NullConnection.cs
+++ b/tests/NexusMods.MnemonicDB.Storage.Tests/NullConnection.cs
@@ -29,7 +29,7 @@ public class NullConnection : IConnection
         throw new NotSupportedException();
     }
 
-    public ITransaction BeginTransaction()
+    public IMainTransaction BeginTransaction()
     {
         throw new NotSupportedException();
     }


### PR DESCRIPTION
Adds `IMainTransaction` returned by `IConnection.BeginTransaction` and `ISubTransaction` returned by `ITransaction.CreateSubTransaction`.

You can now reset transactions explicitly with `ITransaction.Reset` and committing has been removed from `ITransaction` and put into `IMainTransaction` and `ISubTransaction`.