### PR TITLE
Fix cascade queries "unable to compare elements" errors 

### DIFF
--- a/src/NexusMods.MnemonicDB.Abstractions/ElementComparers/Null.cs
+++ b/src/NexusMods.MnemonicDB.Abstractions/ElementComparers/Null.cs
@@ -1,10 +1,13 @@
-﻿namespace NexusMods.MnemonicDB.Abstractions.ElementComparers;
+﻿using System;
+
+namespace NexusMods.MnemonicDB.Abstractions.ElementComparers;
 
 /// <summary>
 /// A null value, used to represent a null as a value. This is mostly used for
 /// marker attributes that don't have a value.
 /// </summary>
-public readonly struct Null
+public readonly struct Null : IComparable<Null>, IEquatable<Null>, IComparable
+
 {
     private readonly int _dummy; // This is to ensure that the struct is not default
 
@@ -27,5 +30,46 @@ public readonly struct Null
     public override string ToString()
     {
         return "Null";
+    }
+    
+    /// <summary>
+    /// Compares this instance with another Null instance.
+    /// </summary>
+    /// <param name="other">The other Null instance to compare with.</param>
+    /// <returns>0 if they are equal, -1 if this is default and other is not, 1 if this is not default and other is.</returns>
+    public int CompareTo(Null other)
+    {
+        // Compare based on _dummy value
+        return _dummy.CompareTo(other._dummy);
+    }
+    
+    /// <summary>
+    /// Implements IComparable interface.
+    /// </summary>
+    public int CompareTo(object? obj)
+    {
+        if (obj is null) return 1;
+        if (obj is Null other) return CompareTo(other);
+        throw new ArgumentException("Object must be of type Null", nameof(obj));
+    }
+    
+    /// <summary>
+    /// Determines whether this instance is equal to another Null instance.
+    /// </summary>
+    public bool Equals(Null other)
+    {
+        return _dummy == other._dummy;
+    }
+    
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return obj is Null other && Equals(other);
+    }
+    
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        return _dummy;
     }
 }


### PR DESCRIPTION
Add IComparable and IEquatable to ElementComparers.Null, required for Cascade queries to work correctly