### PR TITLE
Use synchronous APIs for the event thread

### DIFF
--- a/src/NexusMods.MnemonicDB/Connection.cs
+++ b/src/NexusMods.MnemonicDB/Connection.cs
@@ -106,8 +106,8 @@ public sealed class Connection : IConnection
 
             try
             {
-                UnsubscribeAll(events.OfType<UnSubscribeEvent>());
                 ObserveAll(events.OfType<IObserveDatomsEvent>().ToArray());
+                UnsubscribeAll(events.OfType<UnSubscribeEvent>());
                 ProcessNewRevisions(events.OfType<NewRevisionEvent>());
             }
             catch (Exception e)

--- a/src/NexusMods.MnemonicDB/EventTypes/NewRevsionEvent.cs
+++ b/src/NexusMods.MnemonicDB/EventTypes/NewRevsionEvent.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using NexusMods.MnemonicDB.Abstractions;
 
@@ -6,4 +7,4 @@ namespace NexusMods.MnemonicDB.EventTypes;
 /// <summary>
 /// A new DB revision event
 /// </summary>
-internal record NewRevisionEvent(IDb? Prev, IDb Db, TaskCompletionSource OnFinished) : IEvent;
+internal record NewRevisionEvent(IDb? Prev, IDb Db, SemaphoreSlim OnFinished) : IEvent;


### PR DESCRIPTION
- Uses `BlockingCollection` instead of `Channel` for pending events
- Uses `SemaphoreSlim` instead of `TaskCompletionSource` for `NewRevisionEvent`

The `Channel` API is async, but we're using it in a synchronous context since we create and manage a thread that just runs `ProcessEvents`. I believe `BlockingCollection` fits this use-case more, as it's a fully synchronous API.

The `NewRevisionEvent` was using `TaskCompletionSource` as a DIY synchronization primitive, I've changed that to use `SemaphoreSlim` instead since it was also used in a purely synchronous fashion.