### PR TITLE
Fix hanging on `QueryEngine.DisposeAsync()`

### DIFF
--- a/src/NexusMods.HyperDuck/DuckDB.cs
+++ b/src/NexusMods.HyperDuck/DuckDB.cs
@@ -75,7 +75,7 @@ public class DuckDB : IAsyncDisposable, IQueryMixin
         
         _disposed = true;
         if (LiveQueryUpdater.IsValueCreated)
-            await LiveQueryUpdater.Value.DisposeAsync();
+            await LiveQueryUpdater.Value.DisposeAsync().ConfigureAwait(false);
         
         while (_allConnections.TryTake(out var connection))
         {

--- a/src/NexusMods.HyperDuck/Internals/LiveQueryUpdater.cs
+++ b/src/NexusMods.HyperDuck/Internals/LiveQueryUpdater.cs
@@ -69,8 +69,8 @@ public class LiveQueryUpdater : IAsyncDisposable
         // It's a bit of deep async lore, but `.CancelAsync` will sometimes run
         // the cancellation callbacks on the caller threads, which can hang the code
         // The CancelAfter variant doesn't have that issue. 
-        _cancelationToken.CancelAfter(0); 
-        await _task;
+        _cancelationToken.CancelAfter(0);
+        await _task.ConfigureAwait(false);
         _task = null;
         _liveQueries.Clear();
         _pendingFlushes = ImmutableStack<TaskCompletionSource>.Empty;
@@ -83,7 +83,7 @@ public class LiveQueryUpdater : IAsyncDisposable
 
     public Task FlushAsync()
     {
-        var tcs = new TaskCompletionSource();
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         while (true)
         {
             var oldFlushes = _pendingFlushes;

--- a/src/NexusMods.MnemonicDB/QueryEngine.cs
+++ b/src/NexusMods.MnemonicDB/QueryEngine.cs
@@ -74,7 +74,7 @@ public class QueryEngine : IQueryEngine, IAsyncDisposable
         _valueUnion.Dispose();
         _valueTagEnum.Dispose();
         _attrEnumLogicalType.Dispose();
-        await _db.DisposeAsync();
+        await _db.DisposeAsync().ConfigureAwait(false);
     }
 
     public HyperDuck.DuckDB DuckDb => _db;


### PR DESCRIPTION
It was hanging because it wasn't able to schedule the continuation on the original thread (blocked on something else apparently).

This was hard to debug, as unblocking one thing would just result in something else getting blocked.

With these changes though the app seems to no longer hang and closes itself correctly.
(Tested after setting up project references in the app)  