### PR TITLE
Use `Boolean` instead of `TinyInt` for `bool` values

### DIFF
--- a/src/NexusMods.MnemonicDB.Abstractions/ElementComparers/ValueTags.cs
+++ b/src/NexusMods.MnemonicDB.Abstractions/ElementComparers/ValueTags.cs
@@ -1,6 +1,7 @@
 ﻿// ReSharper disable InconsistentNaming
 
 using System;
+using System.Diagnostics;
 using NexusMods.HyperDuck;
 // ReSharper disable NotDisposedResource
 
@@ -131,8 +132,15 @@ public static class ValueTagsExtensions
             [LogicalType.From<ushort>(), LogicalType.From<string>()]);
     }
 
-    public static LogicalType DuckDbType(this ValueTag tag)
+    public static LogicalType DuckDbType(this ValueTag tag, Type valueType)
     {
+        if (valueType == typeof(bool) && tag == ValueTag.UInt8)
+        {
+            var type = _duckDbTypes[(int)ValueTag.Null];
+            Debug.Assert(type.TypeId == HyperDuck.DuckDbType.Boolean);
+            return type;
+        }
+
         return _duckDbTypes[(int)tag];
     }
 }

--- a/src/NexusMods.MnemonicDB/QueryFunctions/DatomsTableFunction.cs
+++ b/src/NexusMods.MnemonicDB/QueryFunctions/DatomsTableFunction.cs
@@ -254,7 +254,7 @@ public class DatomsTableFunction : ATableFunction
         if (state.Mode == ScanMode.SingleAttribute)
         {
             info.AddColumn<ulong>("E");
-            info.AddColumn("V", state.Attribute!.LowLevelType.DuckDbType());
+            info.AddColumn("V", state.Attribute!.LowLevelType.DuckDbType(state.Attribute.ValueType));
             info.AddColumn<ulong>("T");
         }
         else

--- a/src/NexusMods.MnemonicDB/QueryFunctions/ModelTableFunction.cs
+++ b/src/NexusMods.MnemonicDB/QueryFunctions/ModelTableFunction.cs
@@ -396,13 +396,13 @@ public class ModelTableFunction : ATableFunction
         {
             if (attr.Cardinalty == Cardinality.Many)
             {
-                var baseType = attr.LowLevelType.DuckDbType();
+                var baseType = attr.LowLevelType.DuckDbType(attr.ValueType);
                 using var listType = LogicalType.CreateListOf(baseType);
                 info.AddColumn(attr.Id.Name, listType);
             }
             else
             {
-                info.AddColumn(attr.Id.Name, attr.LowLevelType.DuckDbType());
+                info.AddColumn(attr.Id.Name, attr.LowLevelType.DuckDbType(attr.ValueType));
             }
         }
 


### PR DESCRIPTION
`BooleanAttribute` was mapped to a `TinyInt` column because the `ValueTag` was `UInt8` which mapped to `TinyInt`. Taking also the C# type into account we can map `BooleanAttribute` to `Boolean` for DuckDB.

This shouldn't need any other changes on the data itself just telling DuckDB how to interpret it.

Closes #163.