### PR TITLE
Don't clear the source cache update in place if possible

### DIFF
--- a/src/NexusMods.HyperDuck/Adaptor/Impls/ResultAdaptors/SourceCacheAdaptor.cs
+++ b/src/NexusMods.HyperDuck/Adaptor/Impls/ResultAdaptors/SourceCacheAdaptor.cs
@@ -17,7 +17,7 @@ public class SourceCacheAdaptor<TRowType, TKey, TRowAdaptor> : IResultAdaptor<So
         
         value.Edit(updater =>
         {
-            var existingKeys = new HashSet<TKey>(updater.Items.Select(keySelector));
+            var existingKeys = updater.Keys.ToHashSet();
     
             Span<ReadOnlyVector> vectors = stackalloc ReadOnlyVector[(int)columnCount];
             while (true)


### PR DESCRIPTION
- Fixes https://github.com/Nexus-Mods/NexusMods.App/issues/3859

This doesn't check if the item actually changed, so this still issues updates with identical values.
Need a separate fix for checking if the value changed.