### PR TITLE
Fix Observe Datoms behavior with updates

### DIFF
--- a/tests/NexusMods.MnemonicDB.Tests/DbTests.cs
+++ b/tests/NexusMods.MnemonicDB.Tests/DbTests.cs
@@ -651,6 +651,214 @@ public class DbTests(IServiceProvider provider) : AMnemonicDBTest(provider)
     }
 
     [Test]
+    public async Task ObserveDatomsEmitsUpdatesForScalarChanges()
+    {
+        var loadout = await InsertExampleData();
+        var targetMod = loadout.Mods.First();
+        var originalName = targetMod.Name;
+        var newName = originalName + " (Renamed)";
+
+        var slice = SliceDescriptor.Create(Mod.Name, AttributeCache);
+
+        var tcs = new TaskCompletionSource<IChangeSet<Datom, DatomKey>>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var subscription = Connection.ObserveDatoms(slice)
+            .Subscribe(changeSet =>
+            {
+                if (changeSet.Updates == 0)
+                    return;
+
+                tcs.TrySetResult(changeSet);
+            });
+
+        using (var tx = Connection.BeginTransaction())
+        {
+            tx.Add(targetMod.Id, Mod.Name, newName);
+            await tx.Commit();
+        }
+
+        var changeSet = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+        await Assert.That(changeSet.Adds).IsEqualTo(0).Because("scalar updates should not appear as adds");
+        await Assert.That(changeSet.Removes).IsEqualTo(0).Because("scalar updates should not appear as removes");
+        await Assert.That(changeSet.Updates).IsEqualTo(1).Because("the change should surface as a single update");
+
+        var update = changeSet.Single(change => change.Reason == ChangeReason.Update);
+        var resolver = Connection.AttributeResolver;
+
+        var currentName = resolver.Resolve(update.Current).ObjectValue?.ToString();
+        await Assert.That(currentName).IsEqualTo(newName);
+
+        var previous = update.Previous;
+        await Assert.That(previous.HasValue).IsTrue();
+
+        var previousName = resolver.Resolve(previous.Value).ObjectValue?.ToString();
+        await Assert.That(previousName).IsEqualTo(originalName);
+    }
+
+    [Test]
+    public async Task ObserveDatomsEmitsAddsForCollectionAttributes()
+    {
+        var loadout = await InsertExampleData();
+        var targetMod = loadout.Mods.First();
+        const string newTag = "New Tag";
+
+        var slice = SliceDescriptor.Create(Mod.Tags, AttributeCache);
+        var resolver = Connection.AttributeResolver;
+
+        var tcs = new TaskCompletionSource<IChangeSet<Datom, DatomKey>>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var subscription = Connection.ObserveDatoms(slice)
+            .Subscribe(changeSet =>
+            {
+                foreach (var change in changeSet)
+                {
+                    if (change.Reason != ChangeReason.Add)
+                        continue;
+
+                    var value = resolver.Resolve(change.Current).ObjectValue?.ToString();
+                    if (value == newTag)
+                    {
+                        tcs.TrySetResult(changeSet);
+                        break;
+                    }
+                }
+            });
+
+        using (var tx = Connection.BeginTransaction())
+        {
+            tx.Add(targetMod.Id, Mod.Tags, newTag);
+            await tx.Commit();
+        }
+
+        var changeSet = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+        await Assert.That(changeSet.Adds).IsEqualTo(1).Because("collection additions should surface as adds");
+        await Assert.That(changeSet.Removes).IsEqualTo(0);
+        await Assert.That(changeSet.Updates).IsEqualTo(0);
+
+        var addition = changeSet.Single(change => change.Reason == ChangeReason.Add);
+        var addedValue = resolver.Resolve(addition.Current).ObjectValue?.ToString();
+        await Assert.That(addedValue).IsEqualTo(newTag);
+    }
+
+    [Test]
+    public async Task ObserveDatomsEmitsRemovesForCollectionAttributes()
+    {
+        var loadout = await InsertExampleData();
+        var targetMod = loadout.Mods.First();
+        const string tagToRemove = "To Remove";
+
+        using (var tx = Connection.BeginTransaction())
+        {
+            tx.Add(targetMod.Id, Mod.Tags, tagToRemove);
+            await tx.Commit();
+        }
+
+        var slice = SliceDescriptor.Create(Mod.Tags, AttributeCache);
+        var resolver = Connection.AttributeResolver;
+        var tcs = new TaskCompletionSource<IChangeSet<Datom, DatomKey>>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var subscription = Connection.ObserveDatoms(slice)
+            .Subscribe(changeSet =>
+            {
+                foreach (var change in changeSet)
+                {
+                    if (change.Reason != ChangeReason.Remove)
+                        continue;
+
+                    var value = resolver.Resolve(change.Current).ObjectValue?.ToString();
+                    if (value == tagToRemove)
+                    {
+                        tcs.TrySetResult(changeSet);
+                        break;
+                    }
+                }
+            });
+
+        using (var tx = Connection.BeginTransaction())
+        {
+            tx.Retract(targetMod.Id, Mod.Tags, tagToRemove);
+            await tx.Commit();
+        }
+
+        var changeSet = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+        await Assert.That(changeSet.Adds).IsEqualTo(0);
+        await Assert.That(changeSet.Removes).IsEqualTo(1).Because("collection removals should surface as removes");
+        await Assert.That(changeSet.Updates).IsEqualTo(0);
+
+        var removal = changeSet.Single(change => change.Reason == ChangeReason.Remove);
+        var removedValue = resolver.Resolve(removal.Current).ObjectValue?.ToString();
+        await Assert.That(removedValue).IsEqualTo(tagToRemove);
+    }
+
+    [Test]
+    public async Task ObserveDatomsSeparatesScalarAddAndRemoveAcrossTransactions()
+    {
+        var loadout = await InsertExampleData();
+        var targetMod = loadout.Mods.First();
+        var originalName = targetMod.Name;
+        var replacementName = originalName + " (Replacement)";
+
+        var slice = SliceDescriptor.Create(Mod.Name, AttributeCache);
+        var resolver = Connection.AttributeResolver;
+
+        var removeTcs = new TaskCompletionSource<IChangeSet<Datom, DatomKey>>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var addTcs = new TaskCompletionSource<IChangeSet<Datom, DatomKey>>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var subscription = Connection.ObserveDatoms(slice)
+            .Subscribe(changeSet =>
+            {
+                foreach (var change in changeSet)
+                {
+                    var value = resolver.Resolve(change.Current).ObjectValue?.ToString();
+                    switch (change.Reason)
+                    {
+                        case ChangeReason.Remove when value == originalName:
+                            removeTcs.TrySetResult(changeSet);
+                            break;
+                        case ChangeReason.Add when value == replacementName:
+                            addTcs.TrySetResult(changeSet);
+                            break;
+                    }
+                }
+            });
+
+        using (var tx = Connection.BeginTransaction())
+        {
+            tx.Retract(targetMod.Id, Mod.Name, originalName);
+            await tx.Commit();
+        }
+
+        var removeChanges = await removeTcs.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+        using (var tx = Connection.BeginTransaction())
+        {
+            tx.Add(targetMod.Id, Mod.Name, replacementName);
+            await tx.Commit();
+        }
+
+        var addChanges = await addTcs.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+        await Assert.That(removeChanges.Adds).IsEqualTo(0);
+        await Assert.That(removeChanges.Removes).IsEqualTo(1).Because("scalar retracts in their own transaction should surface as removes");
+        await Assert.That(removeChanges.Updates).IsEqualTo(0);
+
+        var removal = removeChanges.Single(change => change.Reason == ChangeReason.Remove);
+        var removedName = resolver.Resolve(removal.Current).ObjectValue?.ToString();
+        await Assert.That(removedName).IsEqualTo(originalName);
+
+        await Assert.That(addChanges.Adds).IsEqualTo(1).Because("scalar asserts in their own transaction should surface as adds");
+        await Assert.That(addChanges.Removes).IsEqualTo(0);
+        await Assert.That(addChanges.Updates).IsEqualTo(0);
+
+        var addition = addChanges.Single(change => change.Reason == ChangeReason.Add);
+        var addedName = resolver.Resolve(addition.Current).ObjectValue?.ToString();
+        await Assert.That(addedName).IsEqualTo(replacementName);
+    }
+
+    [Test]
     public async Task ObserveLargeDatomChanges()
     {
         var list = Connection.ObserveDatoms(Loadout.Name)


### PR DESCRIPTION
This pull request improves how datom changes are processed and observed, especially regarding scalar and collection attributes. The main change refines the logic in `ProcessObservers` to correctly emit updates, adds, and removes for different attribute cardinalities, and introduces comprehensive tests to verify the new behavior.

### Datom Change Processing Improvements

* Refactored the logic in `ProcessObservers` to ensure that scalar attribute changes (cardinality one) are emitted as updates when an add and a retract occur together, rather than as separate add/remove events. This also ensures correct handling of collection attributes (cardinality many) for add and remove operations.

### Expanded Test Coverage for Observed Changes

* Added new tests in `DbTests.cs` to verify that:
  * Scalar attribute changes are emitted as updates, not as adds or removes.
  * Collection attribute additions and removals are emitted as adds and removes, respectively.
  * Scalar adds and removes across separate transactions are correctly surfaced as individual add/remove events, not updates.

These changes ensure more accurate and predictable change notifications for consumers of the datom observation API.