### PR TITLE
Fix timestampNs missing SizeInVector

### DIFF
--- a/src/NexusMods.HyperDuck/LogicalType.cs
+++ b/src/NexusMods.HyperDuck/LogicalType.cs
@@ -69,6 +69,7 @@ public unsafe partial struct LogicalType : IDisposable
         },
         DuckDbType.Union => 0,
         DuckDbType.Blob => sizeof(StringElement),
+        // NOTE(erri120): TIMESTAMP_NS is stored as nanoseconds since 1970-01-01 in int64_t.
         DuckDbType.TimestampNs => sizeof(long),
         _ => throw new NotImplementedException("SizeInVector not implemented for type: " + TypeId)
     };

--- a/src/NexusMods.HyperDuck/LogicalType.cs
+++ b/src/NexusMods.HyperDuck/LogicalType.cs
@@ -69,6 +69,7 @@ public unsafe partial struct LogicalType : IDisposable
         },
         DuckDbType.Union => 0,
         DuckDbType.Blob => sizeof(StringElement),
+        DuckDbType.TimestampNs => sizeof(long),
         _ => throw new NotImplementedException("SizeInVector not implemented for type: " + TypeId)
     };
 


### PR DESCRIPTION
This is causing exceptions in the App when trying to upgrade to mnemonicDb `v0.26.1`.

This is blocking 
- https://github.com/Nexus-Mods/NexusMods.App/issues/3856
- https://github.com/Nexus-Mods/NexusMods.App/issues/3890